### PR TITLE
build(repo): 의존성 호이스팅, tsconfig 통합, 앱 로컬 경로 별칭 제거

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,36 @@
+# Description : .npmrc - 📌 PNPM 워크스페이스 패키지 호이스팅 설정
+# Author : Shiwoo Min
+# Date  : 2025-09-12
+# NOTE:
+#   - public-hoist-pattern 설정을 통해 특정 패키지들을 루트 node_modules로 끌어올려
+#     모든 워크스페이스에서 공유 사용 (중복 설치 방지, 버전 일관성 유지)
+#   - auto-install-peers 설정을 통해 peer dependencies 자동 설치 활성화
+
+# 모든 @types/* 패키지들
+public-hoist-pattern[]=*@types/*
+
+# TypeScript 컴파일러 및 관련 도구들 공통 사용
+public-hoist-pattern[]=typescript
+public-hoist-pattern[]=ts-node
+public-hoist-pattern[]=tsx
+
+# ESLint 관련 패키지들 (플러그인, 설정 등) 통일
+public-hoist-pattern[]=eslint*
+
+# Prettier 포맷터 공통 사용
+public-hoist-pattern[]=prettier
+
+# Vitest 테스트 프레임워크 공유
+public-hoist-pattern[]=vitest
+
+# Vite 빌드 도구 공유
+public-hoist-pattern[]=vite
+
+# Playwright E2E 테스트 도구 및 관련 패키지들
+public-hoist-pattern[]=playwright*
+
+# NestJS 프레임워크 호이스팅
+public-hoist-pattern[]=@nestjs/*
+
+# peer dependencies 자동 설치
+auto-install-peers=true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -296,7 +296,8 @@
     "everysec",
     "requirepass",
     "allkeys",
-    "appendfsync"
+    "appendfsync",
+    "vitest"
   ],
 
   // Nx Console AI 규칙 사용

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@connectwon/admin",
   "version": "1.0.0",
+  "description": "ConnectWon Admin 및 대시보드 페이지",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",
     "build": "next build",
     "start": "next start --port 3001",
     "lint": "next lint",
-    "clean": "rimraf .next dist"
+    "type-check": "pnpm -w exec tsc --noEmit -p tsconfig.json",
+    "clean": "pnpm -w exec rimraf .next dist"
   },
   "dependencies": {
     "next": "^14.2.5",
@@ -15,11 +17,15 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "@types/react": "^18.3.0",
-    "@types/react-dom": "^18.3.0",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.5",
     "autoprefixer": "^10.4.20",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.13",
-    "eslint-config-next": "^14.2.5"
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0"
+  },
+  "engines": {
+    "node": ">=20.11"
   }
 }

--- a/apps/admin/tsconfig.json
+++ b/apps/admin/tsconfig.json
@@ -1,32 +1,40 @@
 /**
- * Description : tsconfig.json - 📌 Admin 앱 TypeScript 설정
+ * Description : tsconfig.json - 📌 Next.js 기반 Admin 앱 (TypeScript 설정)
  * Author : Shiwoo Min
  * Date : 2025-09-11
+ * 09-12 : 브라우저 번들러 해석(ESNext/Bundler), noEmit, 경로매핑 정리
  */
 {
   // 루트의 tsconfig.base.json 상속
   "extends": "../../tsconfig.base.json",
+
   "compilerOptions": {
-    // Next.js가 빌드 처리
+    // Next.js가 빌드/트랜스파일 처리 → TS는 타입체크 전용
     "noEmit": true,
-    // Next.js JSX 처리
+
+    // 브라우저 번들러 기준 해석 (NodeNext를 덮어써 충돌 방지)
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+
+    // Next가 JSX 변환 담당 → preserve
     "jsx": "preserve",
     "plugins": [{ "name": "next" }],
 
-    // Path mapping for packages
+    // 로컬 소스 별칭만 유지, 패키지는 워크스페이스 패키지명(@connectwon/*)으로 임포트
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"],
-      "@ui/*": ["../../packages/ui/src/*"],
-      "@shared/*": ["../../packages/shared/src/*"],
-      "@api-contract/*": ["../../packages/api-contract/src/*"],
-      "@logger/*": ["../../packages/logger/src/*"]
+      "@/*": ["./src/*"]
     },
 
-    // Next.js specific
-    "incremental": true,
-    "types": ["node", "next", "next/types/global"]
+    // 타입 로딩 최소화 (Next 자체 타입 주입 충분)
+    "types": ["node"],
+
+    // 편의: 에디터 캐시 활용
+    "incremental": true
   },
+
+  // Next 자동 생성 타입 선언 포함
   "include": ["next-env.d.ts", "src/**/*", ".next/types/**/*.ts"],
   "exclude": ["node_modules", ".next", "out", "dist"]
 }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@connectwon/api",
   "version": "1.0.0",
-  "private": true,
   "description": "ConnectWon REST-API 기반 백엔드",
+  "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx watch src/app.ts",
-    "build": "tsc",
-    "start": "node dist/app.js",
-    "clean": "rimraf dist",
+    "dev": "pnpm -w exec tsx watch src/main.ts",
+    "build": "pnpm -w exec tsc -p tsconfig.json",
+    "start": "node dist/main.js",
+    "clean": "pnpm -w exec rimraf dist",
     "db:generate": "pnpm --filter=@connectwon/database generate",
     "db:migrate": "pnpm --filter=@connectwon/database migrate",
     "db:studio": "pnpm --filter=@connectwon/database studio"
@@ -19,8 +19,10 @@
     "@nestjs/common": "^11.1.6",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.6",
+    "@nestjs/platform-express": "^11.1.6",
     "@nestjs/swagger": "^11.2.0",
     "bcryptjs": "^2.4.3",
+    "bullmq": "^5.58.5",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
     "cors": "^2.8.5",
@@ -29,25 +31,21 @@
     "ioredis": "^5.7.0",
     "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.0",
-    "reflect-metadata": "^0.2.2",
+    "reflect-metadata": "^0.1.14",
     "swagger-ui-express": "^5.0.1",
     "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",
-    "@types/compression": "^1.8.1",
     "@types/cors": "^2.8.19",
     "@types/express": "^4.17.21",
-    "@types/express-session": "^1.18.2",
     "@types/ioredis": "^5.0.0",
     "@types/jsonwebtoken": "^9.0.7",
     "@types/morgan": "^1.9.10",
     "@types/node": "^24.3.1",
-    "@types/passport": "^1.0.17",
-    "@types/passport-google-oauth20": "^2.0.16",
-    "@types/passport-jwt": "^4.0.1",
-    "@types/passport-local": "^1.0.38",
-    "@types/swagger-ui-express": "^4.1.8",
-    "tsx": "^4.19.3"
+    "@types/swagger-ui-express": "^4.1.8"
+  },
+  "engines": {
+    "node": ">=20.11"
   }
 }

--- a/apps/api/src/modules/index.ts
+++ b/apps/api/src/modules/index.ts
@@ -1,0 +1,34 @@
+/**
+ * Description : index.ts - 📌 도메인 모듈 
+ * Author : Shiwoo Min
+ * Date : 2025-09-12
+ */
+import { AiModule } from './ai/module.js';
+import { AuthModule } from './auth/module.js';
+import { PaymentsModule } from './payments/module.js';
+import { ProgramsModule } from './programs/module.js';
+import { ReservationModule } from './reservation/module.js';
+import { UsersModule } from './users/module.js';
+import { VenuesModule } from './venues/module.js';
+
+// AppModule에서 한 번에 가져다 쓰기 위한 모듈 묶음
+export const ApiModules = [
+  AiModule,
+  AuthModule,
+  PaymentsModule,
+  ProgramsModule,
+  ReservationModule,
+  UsersModule,
+  VenuesModule,
+] as const;
+
+// 필요 시 개별 모듈도 바로 import 가능하도록 재노출
+export {
+  AiModule,
+  AuthModule,
+  PaymentsModule,
+  ProgramsModule,
+  ReservationModule,
+  UsersModule,
+  VenuesModule,
+};

--- a/apps/api/src/modules/payments/dto.ts
+++ b/apps/api/src/modules/payments/dto.ts
@@ -1,11 +1,9 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
-  IsEmail,
   IsEnum,
   IsInt,
   IsNotEmpty,
-  IsNumber,
   IsObject,
   IsOptional,
   IsPositive,

--- a/apps/api/src/modules/reservation/dto.ts
+++ b/apps/api/src/modules/reservation/dto.ts
@@ -1,7 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
-  IsArray,
   IsBoolean,
   IsDateString,
   IsEnum,

--- a/apps/api/src/modules/venues/dto.ts
+++ b/apps/api/src/modules/venues/dto.ts
@@ -7,8 +7,8 @@ import {
   IsEnum,
   IsInt,
   IsNotEmpty,
-  IsNumber,
   IsObject,
+  
   IsOptional,
   IsPositive,
   IsString,

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,7 +1,8 @@
 /**
- * Description : tsconfig.json - 📌 api 의 tsconfig.json 최소유지 (Express API)
+ * Description : tsconfig.json - 📌 Nest/Express API 모듈  (TypeScript 설정)
  * Author : Shiwoo Min
  * Date : 2025-09-06
+ * 09-12 : 소스맵/증분빌드/tsbuildinfo 추가, 라이브러리 스킵체크 활성화
  */
 {
   // 루트의 tsconfig.base.json 상속
@@ -24,18 +25,27 @@
     // 기본 내보내기 호환성 설정
     "allowSyntheticDefaultImports": true,
 
-    // 데코레이터 필수
+    // 데코레이터 필수 (class-validator / class-transformer)
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
 
     // TS5 + 데코레이터/클래스필드 안전장치
     "useDefineForClassFields": false,
 
-    // 엄격한 타입 검사 설정
+    // 엄격한 타입 검사 설정(루트가 strict이므로 필요한 것만 오버라이드)
     "strictPropertyInitialization": false,
 
-    // JS 파일 생성 여부 (false면 tsc --noEmit 처럼 작동)
+    // 산출물/디버깅
     "noEmit": false,
+    "sourceMap": true,
+
+    // 모노레포 증분 빌드(속도 ↑)
+    "composite": true,
+    "incremental": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+
+    // 외부 d.ts 검사는 스킵(속도/잡음 ↓)
+    "skipLibCheck": true,
 
     // DOM 타입 제거, node 전용 타입만 포함
     "types": ["node"]

--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -1,19 +1,25 @@
 {
   "name": "@connectwon/e2e",
   "version": "1.0.0",
+  "description": "ConnectWon E2E 테스트",
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "playwright test",
-    "test:ui": "playwright test --ui",
-    "test:report": "playwright show-report",
-    "test:debug": "playwright test --debug"
+    "test": "pnpm -w exec playwright test",
+    "test:ui": "pnpm -w exec playwright test --ui",
+    "test:report": "pnpm -w exec playwright show-report",
+    "test:debug": "pnpm -w exec playwright test --debug",
+    "install:browsers": "pnpm -w exec playwright install --with-deps",
+    "clean": "pnpm -w exec rimraf playwright-report test-results"
   },
   "devDependencies": {
     "@connectwon/api-contract": "workspace:*",
     "@connectwon/logger": "workspace:*",
-    "@playwright/test": "^1.40.0",
+    "@playwright/test": "^1.51.1",
     "@types/dotenv": "^8.2.3",
     "dotenv": "^17.2.2"
+  },
+  "engines": {
+    "node": ">=20.11"
   }
 }

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -1,59 +1,58 @@
 /**
  * Description : playwright.config.ts - 📌 Playwright 테스트 실행 환경 정의 파일
- * Author      : Shiwoo Min
- * Date        : 2025-09-07
- * Note        : 최소 설정으로 웹/모바일 웹 E2E 테스트만 진행
+ * Author : Shiwoo Min
+ * Date : 2025-09-07
+ * 09-07 : 최소 설정으로 웹/모바일 웹 E2E 테스트만 진행
  */
-
-import { defineConfig, devices } from '@playwright/test'
-import dotenv from 'dotenv'
-import os from 'os'
-import path from 'path'
-import { dirname } from 'path'
-import { fileURLToPath } from 'url'
+import { defineConfig, devices } from '@playwright/test';
+import dotenv from 'dotenv';
+import os from 'os';
+import path from 'path';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
 
 // ESM 경로 유틸
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 // .env 로드 (이 파일과 같은 폴더의 .env)
-dotenv.config({ path: path.resolve(__dirname, '.env') })
+dotenv.config({ path: path.resolve(__dirname, '.env') });
 
 // ENV 헬퍼 (대괄호 접근 + 안전 파싱)
-const truthy = new Set(['1', 'true', 'yes', 'on'])
-const falsy = new Set(['0', 'false', 'no', 'off'])
-const env = (k: string) => process.env[k]
+const truthy = new Set(['1', 'true', 'yes', 'on']);
+const falsy = new Set(['0', 'false', 'no', 'off']);
+const env = (k: string) => process.env[k];
 
 const envBool = (k: string, def: boolean) => {
-  const raw = env(k)
-  if (raw == null) return def
-  const v = raw.toLowerCase()
-  if (truthy.has(v)) return true
-  if (falsy.has(v)) return false
-  return def
-}
+  const raw = env(k);
+  if (raw == null) return def;
+  const v = raw.toLowerCase();
+  if (truthy.has(v)) return true;
+  if (falsy.has(v)) return false;
+  return def;
+};
 const envInt = (k: string, def: number) => {
-  const n = Number.parseInt(String(env(k) ?? ''), 10)
-  return Number.isFinite(n) ? n : def
-}
-const envStr = (k: string, def: string) => env(k) ?? def
+  const n = Number.parseInt(String(env(k) ?? ''), 10);
+  return Number.isFinite(n) ? n : def;
+};
+const envStr = (k: string, def: string) => env(k) ?? def;
 
 // 파싱된 ENV
-const IS_CI  = envBool('CI', false)
-const HEADLESS = envBool('HEADLESS', true) // false면 UI(headed) 모드
-const BASE_URL = envStr('BASE_URL', 'http://localhost:3000')
+const IS_CI = envBool('CI', false);
+const HEADLESS = envBool('HEADLESS', true); // false면 UI(headed) 모드
+const BASE_URL = envStr('BASE_URL', 'http://localhost:3000');
 
 // CI면 2회, 아니면 0 (원하면 RETRIES로 override 가능)
-const RETRIES = envInt('RETRIES', IS_CI ? 2 : 0)
+const RETRIES = envInt('RETRIES', IS_CI ? 2 : 0);
 // CI=1 → 워커 1, 로컬 → CPU 75% (최소 1)
-const WORKERS = IS_CI ? 1 : Math.max(1, Math.floor(os.cpus().length * 0.75))
+const WORKERS = IS_CI ? 1 : Math.max(1, Math.floor(os.cpus().length * 0.75));
 
 // 타임아웃/슬로모션
-const GLOBAL_TIMEOUT_MS         = 30 * 60 * 1000 // 30분
-const ACTION_TIMEOUT_MS         = envInt('ACTION_TIMEOUT', 30) * 1000
-const NAVIGATION_TIMEOUT_MS     = envInt('NAVIGATION_TIMEOUT', 60) * 1000
-const SLOW_MO_MS                = envInt('SLOW_MO', 0)
-const BROWSER_LAUNCH_TIMEOUT_MS = envInt('BROWSER_LAUNCH_TIMEOUT', 60_000)
+const GLOBAL_TIMEOUT_MS = 30 * 60 * 1000; // 30분
+const ACTION_TIMEOUT_MS = envInt('ACTION_TIMEOUT', 30) * 1000;
+const NAVIGATION_TIMEOUT_MS = envInt('NAVIGATION_TIMEOUT', 60) * 1000;
+const SLOW_MO_MS = envInt('SLOW_MO', 0);
+const BROWSER_LAUNCH_TIMEOUT_MS = envInt('BROWSER_LAUNCH_TIMEOUT', 60_000);
 
 // 공통 use 옵션
 const commonUse = {
@@ -66,7 +65,7 @@ const commonUse = {
   screenshot: 'only-on-failure' as const,
   video: 'retain-on-failure' as const,
   trace: 'on-first-retry' as const,
-}
+};
 
 // 프로젝트 정의
 const desktopProject = {
@@ -87,7 +86,7 @@ const desktopProject = {
       timeout: BROWSER_LAUNCH_TIMEOUT_MS,
     },
   },
-}
+};
 
 const mobileProject = {
   name: 'Mobile Chrome',
@@ -104,17 +103,17 @@ const mobileProject = {
       timeout: BROWSER_LAUNCH_TIMEOUT_MS,
     },
   },
-}
+};
 
 // webServer: 조건 만족 시에만 키 추가
 const webServer = envBool('START_WEB_SERVER', false)
   ? {
       command: envStr('WEB_COMMAND', 'pnpm dev'),
-      url:     envStr('WEB_URL', 'http://localhost:3000'),
+      url: envStr('WEB_URL', 'http://localhost:3000'),
       reuseExistingServer: true,
       timeout: 120_000,
     }
-  : undefined
+  : undefined;
 
 // 최종 설정
 export default defineConfig({
@@ -129,11 +128,8 @@ export default defineConfig({
 
   use: commonUse,
   projects: [desktopProject, mobileProject],
-  reporter: [
-    ['list'],
-    ['html', { open: 'never' }],
-  ],
+  reporter: [['list'], ['html', { open: 'never' }]],
 
   // exactOptionalPropertyTypes 대응
   ...(webServer ? { webServer } : {}),
-})
+});

--- a/apps/e2e/tsconfig.json
+++ b/apps/e2e/tsconfig.json
@@ -1,26 +1,58 @@
 /**
- * Description : tsconfig.json - 📌 Playwright 설정 관련 타입정의
+ * Description : tsconfig.json - 📌 Playwright 기반 E2E 모듈 (TypeScript 설정)
  * Author : Shiwoo Min
  * Date : 2025-09-07
+ * 09-12 : include 범위 축소(교차 패키지 소스 제외), DOM 타입 유지, noEmit 확정
  */
 {
+  // 루트 공통 규칙 상속
   "extends": "../../tsconfig.base.json",
+
   "compilerOptions": {
+    // Node 런타임에서의 ESM 해석
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "target": "es2022",
-    "lib": ["es2022", "DOM", "DOM.Iterable"],
+
+    // 테스트 러너는 Node, 브라우저는 자동화 대상 → ES2022 + DOM 타입 병행
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+
+    // 상호운용/편의
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
+
+    // JS 기반 유틸/헬퍼를 허용하려면 true 유지 (JS 파일 없으면 false로 바꿔도 됨)
     "allowJs": true,
+
+    // 엄격 모드 + 타입 전용(산출물은 없음)
     "strict": true,
     "noEmit": true,
+
+    // Playwright/Node 타입 명시
     "types": ["node", "@playwright/test"],
+
+    // 자잘한 성능/안전
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "isolatedModules": true
   },
-  "include": ["**/*.ts", "**/*.js", "../../packages/logger/**/*.ts", "../../packages/configs/testing/playwright.ts"],
-  "exclude": ["node_modules", "test-results", "playwright-report"]
+
+  // e2e 프로젝트 내부만 포함
+  "include": [
+    "playwright.config.ts",
+    "e2e-types.ts",
+    "GlobalSetup.ts",
+    "GlobalTeardown.ts",
+    "actions/**/*.ts",
+    "locators/**/*.ts",
+    "tests/**/*.ts",
+    // JS 헬퍼를 쓰면 아래 라인 유지
+    "actions/**/*.js",
+    "locators/**/*.js",
+    "tests/**/*.js"
+  ],
+
+  // 산출물/리포트/노드모듈 제외
+  "exclude": ["node_modules", "dist", "test-results", "playwright-report"]
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,14 +1,15 @@
 {
   "name": "@connectwon/web",
   "version": "1.0.0",
+  "description": "ConnectWon 사용자 웹 애플리케이션",
   "private": true,
   "scripts": {
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "type-check": "tsc --noEmit",
-    "clean": "rimraf .next dist"
+    "type-check": "pnpm -w exec tsc --noEmit -p tsconfig.json",
+    "clean": "pnpm -w exec rimraf .next dist"
   },
   "dependencies": {
     "next": "^14.2.5",
@@ -21,15 +22,15 @@
     "clsx": "^2.0.0"
   },
   "devDependencies": {
-    "@types/react": "^18.3.0",
-    "@types/react-dom": "^18.3.0",
-    "@types/node": "^20.0.0",
-    "typescript": "^5.0.0",
-    "eslint": "^8.0.0",
+    "eslint": "^8.57.0",
     "eslint-config-next": "^14.2.5",
     "autoprefixer": "^10.4.20",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.13",
-    "rimraf": "^5.0.0"
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0"
+  },
+  "engines": {
+    "node": ">=20.11"
   }
 }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,31 +1,37 @@
 /**
- * Description : tsconfig.json - 📌 web 의 tsconfig.json 최소유지
+ * Description : tsconfig.json - 📌 Next.js 기반 Web 애플리케이션 (TypeScript 설정)
  * Author : Shiwoo Min
  * Date : 2025-09-06
+ * 09-12 : 브라우저 번들러 해석(ESNext/Bundler), noEmit/Next 플러그인 추가, include 정리
  */
 {
   // 루트 공통 규칙 상속
   "extends": "../../tsconfig.base.json",
 
   "compilerOptions": {
-    // React/Next.js에 필요한 추가 설정
-    "jsx": "react-jsx",
+    // 브라우저 번들러 기준 해석 (NodeNext를 덮어써서 충돌 방지)
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
 
-    // 타입 로딩 명시
-    "types": ["node", "react", "react-dom", "tailwindcss"],
+    // Next는 자체 트랜스폼을 하므로 preserve가 가장 무난
+    "jsx": "preserve",
 
-    // JS도 import 허용
+    // 타입 로딩 (Next가 대부분 자동 주입하므로 최소화)
+    "types": ["node"],
+
+    // 산출물은 Next가 담당 → TS는 타입체크 전용
+    "noEmit": true,
+
+    // JS/JSON import 허용
     "allowJs": true,
+    "resolveJsonModule": true,
 
-    // JSON import 허용
-    "resolveJsonModule": true
-
-    // 아래 항목들은 Next.js에서 직접 tsc로 빌드하지 않기 때문에 생략 가능
-    // "outDir": "dist",
-    // "rootDir": "src"
+    // Next.js 전용 TS 플러그인(경고/권장 설정 안내)
+    "plugins": [{ "name": "next" }]
   },
 
-  // Next 자동 생성 타입 파일 포함
-  "include": ["src", "next-env.d.ts", "ui.ts"],
+  // Next가 생성하는 타입 선언 포함 필수
+  "include": ["next-env.d.ts", "src", "ui.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,19 +1,21 @@
 {
   "name": "@connectwon/worker",
+  "version": "1.0.0",
+  "description": "ConnectWon 백그라운드 워커 서비스 (BullMQ 기반)",
   "private": true,
-  "version": "0.0.0",
-  "description": "Connectwon 백그라운드 워커 서비스 (BullMQ 기반)",
   "type": "module",
   "scripts": {
     "dev": "nx serve worker",
     "build": "nx build worker",
-    "start": "node dist/apps/worker/main.js"
+    "start": "node dist/apps/worker/main.js",
+    "clean": "pnpm -w exec rimraf dist"
   },
   "dependencies": {
     "@connectwon/core": "workspace:*",
     "bullmq": "^5.58.5"
   },
-  "devDependencies": {
-    "@types/node": "^20.19.13"
+  "devDependencies": {},
+  "engines": {
+    "node": ">=20.11"
   }
 }

--- a/apps/worker/tsconfig.json
+++ b/apps/worker/tsconfig.json
@@ -1,44 +1,52 @@
 /**
- * Description : tsconfig.json - 📌 api 의 tsconfig.json 최소유지 (Express API)
- * Author : Shiwoo Min
- * Date : 2025-09-06
+ * Description : tsconfig.json - 📌 BullMQ 기반 Worker (TypeScript 설정)
+ * Author      : Shiwoo Min
+ * Date        : 2025-09-06
+ * 09-12 : NodeNext/ES2022, d.ts/소스맵/증분빌드, 서버전용 lib로 정리
  */
 {
   // 루트의 tsconfig.base.json 상속
   "extends": "../../tsconfig.base.json",
 
   "compilerOptions": {
-    // API 소스 루트
+    // 입력/출력 경로
     "rootDir": "./src",
 
     // 빌드 결과 위치
     "outDir": "./dist",
 
-    // 모듈 시스템 설정 (Nest, Express 등 Node 환경)
+    // 워커는 순수 Node 런타임
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "types": ["node"],
+
+    // ESM 해석(NodeNext)
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
 
-    // CommonJS 호환성 설정
+    // 산출물 및 디버깅
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+
+    // 모노레포 증분 빌드
+    "composite": true,
+    "incremental": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+
+    // 상호운용/편의
     "esModuleInterop": true,
 
     // 기본 내보내기 호환성 설정
     "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "exactOptionalPropertyTypes": true
 
-    // JS 파일 생성 여부 (false면 tsc --noEmit 처럼 작동)
-    "noEmit": false,
-
-    // DOM 타입 제거, node 전용 타입만 포함
-    "types": ["node"]
+    // 이벤트 핸들러에서 미사용 매개변수 경고가 거슬리면 아래 중 하나를 고려
+    // "noUnusedParameters": false
   },
 
-  "include": ["src/**/*.ts"],
-
-  "exclude": [
-    "node_modules",
-    "dist",
-    "**/*.test.ts",
-    "**/*.test.tsx",
-    "**/*.spec.ts",
-    "**/*.spec.tsx"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.*", "**/*.spec.*"]
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "connectwon",
-  "private": true,
   "version": "1.0.0",
   "description": "ConnectWon - 도전자들을 위한 예약 기반 생활 서비스",
+  "private": true,
   "type": "module",
   "author": "Shiwoo Min",
   "license": "MIT",
@@ -32,21 +32,7 @@
     "lint:fix": "eslint --ext .ts,.tsx . --fix",
     "commit": "cz"
   },
-  "dependencies": {
-    "bullmq": "^5.58.5",
-    "compression": "^1.8.1",
-    "connect-redis": "^9.0.0",
-    "express-rate-limit": "^8.1.0",
-    "express-session": "^1.18.2",
-    "nx": "^21.4.1",
-    "passport": "^0.7.0",
-    "passport-google-oauth20": "^2.0.0",
-    "passport-jwt": "^4.0.1",
-    "passport-local": "^1.0.0",
-    "redis": "^5.8.2",
-    "winston": "^3.17.0",
-    "winston-daily-rotate-file": "^5.0.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@changesets/cli": "^2.29.6",
     "@eslint/js": "^9",
@@ -102,6 +88,16 @@
     },
     "cz-customizable": {
       "config": "./.cz-config.cjs"
+    }
+  },
+  "pnpm": {
+    "overrides": {
+      "@nestjs/swagger": "^11.2.0",
+      "bullmq": "^5.58.5",
+      "ioredis": "^5.7.0",
+      "winston": "^3.17.0",
+      "@types/node": "^24.3.1",
+      "typescript": "^5.9.2"
     }
   }
 }

--- a/packages/api-contract/package.json
+++ b/packages/api-contract/package.json
@@ -1,10 +1,15 @@
 {
   "name": "@connectwon/api-contract",
   "version": "1.0.0",
+  "description": "API 스키마/타입(zod, ts-rest) 및 OpenAPI 산출용 공용 패키지",
   "private": true,
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -17,11 +22,12 @@
     "./openapi/*": {
       "types": "./dist/openapi/*.d.ts",
       "import": "./dist/openapi/*.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc --watch -p tsconfig.json",
     "clean": "rimraf dist"
   },
   "dependencies": {

--- a/packages/api-contract/tsconfig.json
+++ b/packages/api-contract/tsconfig.json
@@ -1,22 +1,45 @@
 /**
-  * Description : tsconfig.json - 📌 api-contract 의 tsconfig.json 최소유지
-  * Author : Shiwoo Min
-  * Date : 2025-09-05
-  */
+ * Description : tsconfig.json - 📌 API 계약 패키지 (TypeScript 설정)
+ * Author      : Shiwoo Min
+ * Date        : 2025-09-05
+ * 09-12 : ESNext/Bundler 해석, d.ts/소스맵/증분빌드, Node 타입 차단(types: [])
+ */
 
 {
   // 루트의 tsconfig.json 상속
   "extends": "../../tsconfig.base.json",
+
   "compilerOptions": {
-    "composite": true,
-    "declaration": true,
+    // 라이브러리 산출물
     "outDir": "dist",
     "rootDir": "src",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+
+    // 번들러/Node 모두 수월한 isomorphic 설정
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
     "verbatimModuleSyntax": true,
-    "stripInternal": true
+
+    // 선언 파일/소스맵 + 증분 빌드
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "composite": true,
+    "incremental": true,
+    "tsBuildInfoFile": "dist/.tsbuildinfo",
+
+    // 브라우저/서버 공통을 위해 Node 전역타입 유입 차단
+    "lib": ["ES2022"],
+    "types": [],
+
+    // 품질/편의
+    "exactOptionalPropertyTypes": true,
+    "resolveJsonModule": true,
+    "stripInternal": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
   },
+
   "include": ["src/**/*"],
   "exclude": ["dist", "node_modules"]
 }

--- a/packages/configs/package.json
+++ b/packages/configs/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@connectwon/configs",
   "version": "1.0.0",
+  "description": "ConnectWon 공통 설정 Config",
   "private": true,
   "type": "module",
   "sideEffects": false,
-  "description": "ConnectWon 모노레포 프로젝트 공통 설정 파일들을 관리하는 패키지",
   "author": "Shiwoo Min <artiordex@gmail.com>",
   "files": [
     "eslint/*",

--- a/packages/configs/tsconfig.json
+++ b/packages/configs/tsconfig.json
@@ -1,33 +1,43 @@
 /**
- * Description : configs/tsconfig.json - 📌 configs 공통 설정 파일 관리
- * Author : Shiwoo Min
- * Date : 2025-09-05
+ * Description : tsconfig.json - 📌 Config 패키지 (TypeScript 설정)
+ * Author      : Shiwoo Min
+ * Date        : 2025-09-05
  * 09-09 : noEmit=true, include 범위 축소, JS 제외(TS 전용)
+ * 09-12 : NodeNext 해석/JSON 모듈/Node 타입 추가
  */
-
 {
   // 루트의 tsconfig.base.json 상속
   "extends": "../../tsconfig.base.json",
 
   "compilerOptions": {
-    // composite 비활성
-    "composite": false,
-
     // 설정/팩토리 코드만 제공하므로 실제 출력물 생성 안 함
     "noEmit": true,
 
-    // configs는 TS 전용으로 운용
-    "allowJs": false
+    // composite 비활성(프로젝트 레퍼런스 타깃 아님)
+    "composite": false,
 
-    // 필요 시 출력물 생성 위치 지정
-    // "outDir": "./dist"
+    // Node ESM 해석 (config TS 파일 import 시 일관성↑)
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+
+    // configs는 TS 전용으로 운용
+    "allowJs": false,
+
+    // JSON 설정을 TS에서 참조할 수 있게
+    "resolveJsonModule": true,
+
+    // 일부 툴이 Node 전역타입을 기대할 수 있어 명시
+    "types": ["node"],
+
+    // 편의/안전
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
   },
 
   // 포함 범위를 정확히 지정(탐색/타입체크 성능↑)
-  "include": [
-    "eslint/**/*.ts",
-    "tailwind/**/*.ts",
-    "testing/**/*.ts",
-    "typescript/**/*.json"
-  ]
+  "include": ["eslint/**/*.ts", "tailwind/**/*.ts", "testing/**/*.ts", "typescript/**/*.json"],
+
+  "exclude": ["dist", "node_modules"]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,7 @@
   "name": "@connectwon/core",
   "version": "1.0.0",
   "private": true,
+
   "type": "module",
   "sideEffects": false,
   "main": "./dist/index.js",
@@ -32,12 +33,13 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -b",
-    "dev": "tsc -b -w",
-    "clean": "rimraf dist"
+    "build": "pnpm -w exec tsc -b",
+    "dev": "pnpm -w exec tsc -b -w",
+    "clean": "pnpm -w exec rimraf dist",
+    "prepublishOnly": "pnpm run build"
   },
   "engines": {
-    "node": ">=20.10"
+    "node": ">=20.11"
   },
   "dependencies": {
     "@connectwon/logger": "workspace:*",
@@ -68,13 +70,6 @@
     }
   },
   "devDependencies": {
-    "@connectwon/configs": "workspace:*",
-    "@types/bcryptjs": "^2.4.6",
-    "@types/ioredis": "^5.0.0",
-    "@types/jsonwebtoken": "^9.0.7",
-    "@types/nodemailer": "^7.0.1",
-    "@types/js-yaml": "^4.0.9",
-    "rimraf": "^6.0.1",
-    "typescript": "^5.5.4"
+    "@connectwon/configs": "workspace:*"
   }
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,19 +1,52 @@
 /**
- * Description : tsconfig.json - 📌 core 의 tsconfig.json 최소유지
- * Author : Shiwoo Min
- * Date : 2025-09-10
+ * Description : tsconfig.json - 📌 Core 패키지 (TypeScript 설정)
+ * Author      : Shiwoo Min
+ * Date        : 2025-09-10
+ * 09-10 : core 패키지의 domain/authz 참조 추가
+ * 09-12 : 선언파일/소스맵/증분빌드/레퍼런스 정리
  */
 
 {
   // 루트의 tsconfig.json 상속
   "extends": "../../tsconfig.base.json",
+
   "compilerOptions": {
+    // 출력/입력 경로
     "outDir": "./dist",
     "rootDir": ".",
+
+    // 서버 전용 타깃 (브라우저 타입 유입 방지)
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "types": ["node"],
+
+    // Node ESM 해석
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+
+    // 선언 파일 및 디버깅
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+
+    // 모노레포 증분 빌드
     "composite": true,
-    "lib": ["ES2022"]
+    "incremental": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+
+    // 상호운용/편의
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "exactOptionalPropertyTypes": true
   },
-  "include": ["src/**/*.ts", "src/**/**/*.ts", "core-types.ts"],
-  "exclude": ["dist", "node_modules"],
-  "references": [{ "path": "../logger" }, { "path": "../database" }, { "path": "../api-contract" }]
+
+  // 루트에 존재하는 core-types.ts 포함
+  "include": ["src/**/*", "core-types.ts"],
+  "exclude": ["dist", "node_modules", "**/*.test.*", "**/*.spec.*"],
+
+  // 순환 참조 방지: database → core 를 참조할 수 있으므로 core 에서 database 참조는 제거
+  "references": [{ "path": "../logger" }, { "path": "../api-contract" }]
 }

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@connectwon/database",
   "version": "1.0.0",
+  "description": "ConnectWon 데이터베이스 모듈 (Prisma 기반)",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",
@@ -23,19 +24,20 @@
     "studio": "prisma studio",
     "push": "prisma db push",
     "introspect": "prisma db pull",
-    "build": "tsc -p tsconfig.json",
-    "clean": "rimraf dist"
+    "build": "pnpm -w exec tsc -p tsconfig.json",
+    "clean": "pnpm -w exec rimraf dist",
+    "prepublishOnly": "pnpm run build"
   },
   "dependencies": {
     "@connectwon/core": "workspace:*",
     "@connectwon/logger": "workspace:*",
+    "@prisma/client": "^6.15.0",
     "dotenv": "^17.2.2"
   },
   "devDependencies": {
-    "@prisma/client": "^6.15.0",
-    "prisma": "^6.15.0",
-    "rimraf": "^6.0.0",
-    "tsx": "^4.19.3",
-    "typescript": "^5.5.0"
+    "prisma": "^6.15.0"
+  },
+  "engines": {
+    "node": ">=20.11"
   }
 }

--- a/packages/database/tsconfig.json
+++ b/packages/database/tsconfig.json
@@ -4,30 +4,52 @@
  * Date : 2025-09-05
  * 09-07 : prisma 지원 추가
  * 09-10 : core 패키지의 domain/authz 참조 추가
+ * 09-12 : 선언파일/소스맵/증분빌드/레퍼런스 정리
  */
 {
   // 루트의 tsconfig.json 상속
   "extends": "../../tsconfig.base.json",
+
   "compilerOptions": {
+    // 출력/입력 경로
     "outDir": "./dist",
     "rootDir": "./src",
+
+    // 서버 전용 타깃(브라우저 타입 유입 방지)
+    "target": "ES2022",
+    "lib": ["ES2022"],
     "types": ["node"],
-    "composite": true,
+
+    // ESM(NodeNext) 해석
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
+
+    // 선언 파일 및 소스맵 생성
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+
+    // 모노레포 증분 빌드 캐시
+    "composite": true,
+    "incremental": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+
+    // 상호운용/편의
     "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
   },
+
   "include": [
     "src/**/*",
+    // Prisma 시드 스크립트를 TS로 실행할 때 포함
     "prisma/seed.ts"
   ],
-  "exclude": [
-    "dist",
-    "node_modules",
-    "src/generated",
-    "prisma/migrations"
-  ],
-  "references": [
-  ]
+
+  "exclude": ["dist", "node_modules", "src/generated", "prisma/migrations"],
+
+  // 프로젝트 레퍼런스 (DB가 core/logger 타입을 참조한다면 빌드 순서 보장)
+  "references": [{ "path": "../core" }, { "path": "../logger" }]
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,26 +1,35 @@
 {
   "name": "@connectwon/logger",
+  "version": "1.0.0",
+  "description": "ConnectWon 로거 모듈 (Winston 기반)",
+  "private": true,
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
-    "build": "tsc -p tsconfig.json",
-    "dev": "tsc --watch -p tsconfig.json",
-    "clean": "rimraf dist"
+    "build": "pnpm -w exec tsc -p tsconfig.json",
+    "dev": "pnpm -w exec tsc --watch -p tsconfig.json",
+    "clean": "pnpm -w exec rimraf dist",
+    "prepublishOnly": "pnpm run build"
   },
   "dependencies": {
     "logform": "^2.7.0",
-    "winston": "^3.13.0",
-    "winston-daily-rotate-file": "^4.7.1"
+    "winston": "^3.17.0",
+    "winston-daily-rotate-file": "^5.0.0"
   },
-  "devDependencies": {
-    "rimraf": "^6.0.0",
-    "typescript": "^5.5.0"
+  "devDependencies": {},
+  "engines": {
+    "node": ">=20.11"
   }
 }

--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -1,22 +1,46 @@
 /**
- * Description : tsconfig.json - 📌 logger 패키지용 TS 설정
+ * Description : tsconfig.json - 📌 Logger 패키지 (TypeScript 설정)
  * Author : Shiwoo Min
  * Date : 2025-09-10
  */
 {
-  // 루트 tsconfig를 상속
+  // 루트의 tsconfig.base.json 상속
   "extends": "../../tsconfig.base.json",
+
   "compilerOptions": {
+    // I/O 경로
     "rootDir": ".",
     "outDir": "dist",
+
+    // Node ESM 권장
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
+
+    // 런타임 타깃(서버 전용) + DOM 제거
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "types": ["node"],
+
+    // .d.ts 생성 및 소스맵
     "declaration": true,
-    "skipLibCheck": true,
+    "declarationMap": true,
+    "sourceMap": true,
+
+    // 모노레포 참조 빌드 최적화
+    "composite": true,
+    "incremental": true,
+    "tsBuildInfoFile": "dist/.tsbuildinfo",
+
+    // CJS 의존(winston 등)과의 상호운용
     "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+
+    // 품질/편의
+    "skipLibCheck": true,
     "resolveJsonModule": true,
     "forceConsistentCasingInFileNames": true
   },
+
   "include": ["src/**/*", "logger-types.ts"],
   "exclude": ["dist", "node_modules"]
 }

--- a/packages/nest-kit/package.json
+++ b/packages/nest-kit/package.json
@@ -1,13 +1,10 @@
 {
   "name": "@connectwon/nest-kit",
-  "version": "0.1.0",
+  "version": "1.0.0",
+  "description": "ConnectWon NestJS 공통 모듈 및 유틸리티",
+  "private": true,
   "type": "module",
   "sideEffects": false,
-  "peerDependencies": {
-    "next": ">=14",
-    "react": ">=18",
-    "react-dom": ">=18"
-  },
   "exports": {
     ".": "./dist/index.js",
     "./server": "./dist/index.server.js",
@@ -21,20 +18,55 @@
   ],
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
-    "clean": "rimraf dist"
+    "build": "pnpm -w exec tsc -p tsconfig.build.json",
+    "clean": "pnpm -w exec rimraf dist",
+    "prepublishOnly": "pnpm run build"
   },
   "dependencies": {
-    "@nestjs/common": "^11.1.6",
-    "@nestjs/core": "^11.1.6",
-    "@nestjs/swagger": "^11.2.0",
-    "@tanstack/react-query": "^5.87.4",
     "nodemailer": "^7.0.6",
     "rxjs": "^7.8.2",
     "zod": "^3.23.8"
   },
+  "peerDependencies": {
+    "@nestjs/common": "^11.1.6",
+    "@nestjs/core": "^11.1.6",
+    "@nestjs/swagger": "^11.2.0",
+    "@tanstack/react-query": "^5.0.0",
+    "next": ">=14",
+    "react": ">=18",
+    "react-dom": ">=18"
+  },
+  "peerDependenciesMeta": {
+    "@nestjs/common": {
+      "optional": true
+    },
+    "@nestjs/core": {
+      "optional": true
+    },
+    "@nestjs/swagger": {
+      "optional": true
+    },
+    "@tanstack/react-query": {
+      "optional": true
+    },
+    "next": {
+      "optional": true
+    },
+    "react": {
+      "optional": true
+    },
+    "react-dom": {
+      "optional": true
+    }
+  },
   "devDependencies": {
+    "@nestjs/common": "^11.1.6",
+    "@nestjs/core": "^11.1.6",
+    "@nestjs/swagger": "^11.2.0",
     "@types/nodemailer": "^7.0.1",
     "@types/swagger-ui-express": "^4.1.8"
+  },
+  "engines": {
+    "node": ">=20.11"
   }
 }

--- a/packages/nest-kit/tsconfig.json
+++ b/packages/nest-kit/tsconfig.json
@@ -1,33 +1,44 @@
 /**
- * Description : tsconfig.json - 📌 api 의 tsconfig.json 최소유지
+ * Description : tsconfig.json - 📌 Nest.js 패키지 (TypeScript 설정)
  * Author : Shiwoo Min
- * Date : 2025-09-11
+ * Date : 2025-09-12
  */
 {
   // 루트의 tsconfig.base.json 상속
   "extends": "../../tsconfig.base.json",
+
   "compilerOptions": {
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
 
+    // 입출력 경로
     "rootDir": "./src",
     "outDir": "./dist",
     "noEmit": false,
+    // 증분 빌드 캐시
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
 
     // Nest/Express 공통 추천
     "strict": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "useDefineForClassFields": false,
+
+    // ESM/CJS 상호운용
     "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+
+    // 기타
     "resolveJsonModule": true,
     "sourceMap": true,
     "skipLibCheck": true,
-    "jsx": "react-jsx",
-    "jsxImportSource": "react",
-    "types": ["node", "react"]
+
+    // 서버 전용: DOM/React 타입 유입 방지
+    "lib": ["ES2022"],
+    "types": ["node"]
   },
+
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "**/*.test.*", "**/*.spec.*"]
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@connectwon/sdk",
   "version": "1.0.0",
+  "description": "ConnectWon SDK 라이브러리",
   "private": true,
   "type": "module",
   "sideEffects": false,
@@ -16,17 +17,19 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json",
-    "dev": "tsc --watch -p tsconfig.json",
-    "clean": "rimraf dist"
+    "build": "pnpm -w exec tsc -p tsconfig.json",
+    "dev": "pnpm -w exec tsc --watch -p tsconfig.json",
+    "clean": "pnpm -w exec rimraf dist",
+    "prepublishOnly": "pnpm run build"
   },
   "dependencies": {
     "@connectwon/api-contract": "workspace:*",
     "@connectwon/logger": "workspace:*"
   },
   "devDependencies": {
-    "@connectwon/configs": "workspace:*",
-    "typescript": "^5.5.0",
-    "rimraf": "^6.0.0"
+    "@connectwon/configs": "workspace:*"
+  },
+  "engines": {
+    "node": ">=20.11"
   }
 }

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -1,26 +1,47 @@
 /**
- * Description : tsconfig.json - 📌 types 의 tsconfig.json 최소유지
+ * Description : tsconfig.json - 📌 SDK 패키지 (TypeScript 설정)
  * Author : Shiwoo Min
- * Date : 2025-09-09
+ * Date : 2025-09-12
  */
 {
-  // 루트 tsconfig를 상속
+  // 루트의 tsconfig.base.json 상속
   "extends": "../../tsconfig.base.json",
+
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",
-    "moduleResolution": "bundler",
+    // 번들러 소비(Next/Vite/Webpack) 기준 해석
+    "moduleResolution": "Bundler",
+
+    // d.ts 생성 (루트 base에도 있지만 명시 유지)
     "declaration": true,
+
+    // 출력/입력 경로
     "outDir": "./dist",
     "rootDir": ".",
+
+    // 엄격 모드 및 성능
     "strict": true,
     "skipLibCheck": true,
     "exactOptionalPropertyTypes": true,
     "resolveJsonModule": true,
-    "lib": ["ES2022", "DOM"],
-    "composite": true
+
+    // 브라우저 타깃 (Iterable API 사용 시 DOM.Iterable 포함)
+    // 기존: ["ES2022", "DOM"]
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+
+    // 프로젝트 레퍼런스 활성화
+    "composite": true,
+
+    // Node 전역 타입 유입 방지 (isomorphic 충돌 예방)
+    "types": []
   },
+
+  // 루트에 배치한 타입 파일 포함
   "include": ["src/**/*", "sdk-types.ts"],
-  "exclude": ["dist", "node_modules", "../../tools/**/*", "../../tests/**/*"],
+
+  "exclude": ["dist", "node_modules", "../../tools/**/*", "../../tests/**/*", "**/*.test.*"],
+
+  // 의존 패키지 참조
   "references": [{ "path": "../api-contract" }, { "path": "../logger" }]
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,15 +1,16 @@
 {
   "name": "@connectwon/ui",
   "version": "1.0.0",
-  "private": true,
   "description": "ConnectWon UI 컨포넌트 라이브러리",
+  "private": true,
   "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
-    "./styles/*": "./styles/*"
+    "./styles/*": "./styles/*",
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",
@@ -18,10 +19,14 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc -p tsconfig.json",
-    "dev": "tsc -w -p tsconfig.json",
-    "clean": "rimraf dist"
+    "build": "pnpm -w exec tsc -p tsconfig.json",
+    "dev": "pnpm -w exec tsc -w -p tsconfig.json",
+    "clean": "pnpm -w exec rimraf dist",
+    "prepublishOnly": "pnpm run build"
   },
+  "sideEffects": [
+    "*.css"
+  ],
   "dependencies": {
     "class-variance-authority": "^0.7.1"
   },
@@ -30,15 +35,18 @@
     "react-dom": "^18.0.0",
     "recharts": "^3.0.0"
   },
+  "peerDependenciesMeta": {
+    "recharts": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
     "@types/recharts": "^2.0.1",
-    "rimraf": "^6.0.0",
-    "tailwindcss": "^3.4.13",
-    "typescript": "^5.4.0"
+    "tailwindcss": "^3.4.13"
   },
-  "sideEffects": [
-    "*.css"
-  ]
+  "engines": {
+    "node": ">=20.11"
+  }
 }

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,18 +1,36 @@
 /**
- * Description : tsconfig.json - 📌 types 의 tsconfig.json 최소유지
+ * Description : tsconfig.json - 📌 UI 패키지 (TypeScript 설정)
  * Author : Shiwoo Min
- * Date : 2025-09-05
+ * Date : 2025-09-12
  */
 
 {
   // 루트의 tsconfig.json 상속
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    // dist 출력
     "outDir": "./dist",
+
+    // UI 패키지는 루트( . ) 기준으로 컴파일
+    "rootDir": ".",
+
+    // 프로젝트 레퍼런스 대상
     "composite": true,
+
+    // React 17+ JSX 트랜스폼
     "jsx": "react-jsx",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"]
+
+    // 번들러 친화 ESM 해석 (Next/webpack/vite 등 소비자 기준)
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+
+    // 브라우저 타깃
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+
+    // Node 전역 타입 유입 방지 (웹 라이브러리는 비우는 게 안전)
+    "types": []
   },
+  // 루트에 있는 타입 파일도 포함
   "include": ["src/**/*", "src/**/index.ts", "ui-types.ts", "hook-types.ts", "component-types.ts"],
   "exclude": ["dist", "node_modules"],
   "references": []

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,49 +4,17 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@nestjs/swagger': ^11.2.0
+  bullmq: ^5.58.5
+  ioredis: ^5.7.0
+  winston: ^3.17.0
+  '@types/node': ^24.3.1
+  typescript: ^5.9.2
+
 importers:
 
   .:
-    dependencies:
-      bullmq:
-        specifier: ^5.58.5
-        version: 5.58.5
-      compression:
-        specifier: ^1.8.1
-        version: 1.8.1
-      connect-redis:
-        specifier: ^9.0.0
-        version: 9.0.0(express-session@1.18.2)(redis@5.8.2)
-      express-rate-limit:
-        specifier: ^8.1.0
-        version: 8.1.0(express@4.21.2)
-      express-session:
-        specifier: ^1.18.2
-        version: 1.18.2
-      nx:
-        specifier: ^21.4.1
-        version: 21.4.1
-      passport:
-        specifier: ^0.7.0
-        version: 0.7.0
-      passport-google-oauth20:
-        specifier: ^2.0.0
-        version: 2.0.0
-      passport-jwt:
-        specifier: ^4.0.1
-        version: 4.0.1
-      passport-local:
-        specifier: ^1.0.0
-        version: 1.0.0
-      redis:
-        specifier: ^5.8.2
-        version: 5.8.2
-      winston:
-        specifier: ^3.17.0
-        version: 3.17.0
-      winston-daily-rotate-file:
-        specifier: ^5.0.0
-        version: 5.0.0(winston@3.17.0)
     devDependencies:
       '@changesets/cli':
         specifier: ^2.29.6
@@ -116,7 +84,7 @@ importers:
         version: 10.1.8(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.32.0(@typescript-eslint/parser@8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
+        version: 2.32.0(@typescript-eslint/parser@8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-prettier:
         specifier: ^5.2.6
         version: 5.5.4(eslint-config-prettier@10.1.8(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))(prettier@3.6.2)
@@ -138,6 +106,9 @@ importers:
       msw:
         specifier: ^2.7.4
         version: 2.11.1(@types/node@24.3.1)(typescript@5.9.2)
+      nx:
+        specifier: ^21.4.1
+        version: 21.4.1
       prettier:
         specifier: ^3.5.3
         version: 3.6.2
@@ -190,9 +161,12 @@ importers:
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.21(postcss@8.5.6)
+      eslint:
+        specifier: ^8.57.0
+        version: 8.57.1
       eslint-config-next:
         specifier: ^14.2.5
-        version: 14.2.32(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2)
+        version: 14.2.32(eslint@8.57.1)(typescript@5.9.2)
       postcss:
         specifier: ^8.4.47
         version: 8.5.6
@@ -207,22 +181,28 @@ importers:
         version: link:../../packages/database
       '@nestjs/bullmq':
         specifier: ^11.0.3
-        version: 11.0.3(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(bullmq@5.58.5)
+        version: 11.0.3(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.6)(bullmq@5.58.5)
       '@nestjs/common':
         specifier: ^11.1.6
-        version: 11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        version: 11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2)
       '@nestjs/config':
         specifier: ^4.0.2
-        version: 4.0.2(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(rxjs@7.8.2)
+        version: 4.0.2(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(rxjs@7.8.2)
       '@nestjs/core':
         specifier: ^11.1.6
-        version: 11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        version: 11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@11.1.6)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/platform-express':
+        specifier: ^11.1.6
+        version: 11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.6)
       '@nestjs/swagger':
         specifier: ^11.2.0
-        version: 11.2.0(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)
+        version: 11.2.0(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.6)(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)
       bcryptjs:
         specifier: ^2.4.3
         version: 2.4.3
+      bullmq:
+        specifier: ^5.58.5
+        version: 5.58.5
       class-transformer:
         specifier: ^0.5.1
         version: 0.5.1
@@ -248,8 +228,8 @@ importers:
         specifier: ^1.10.0
         version: 1.10.1
       reflect-metadata:
-        specifier: ^0.2.2
-        version: 0.2.2
+        specifier: ^0.1.14
+        version: 0.1.14
       swagger-ui-express:
         specifier: ^5.0.1
         version: 5.0.1(express@4.21.2)
@@ -260,18 +240,12 @@ importers:
       '@types/bcryptjs':
         specifier: ^2.4.6
         version: 2.4.6
-      '@types/compression':
-        specifier: ^1.8.1
-        version: 1.8.1
       '@types/cors':
         specifier: ^2.8.19
         version: 2.8.19
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.23
-      '@types/express-session':
-        specifier: ^1.18.2
-        version: 1.18.2
       '@types/ioredis':
         specifier: ^5.0.0
         version: 5.0.0
@@ -284,24 +258,9 @@ importers:
       '@types/node':
         specifier: ^24.3.1
         version: 24.3.1
-      '@types/passport':
-        specifier: ^1.0.17
-        version: 1.0.17
-      '@types/passport-google-oauth20':
-        specifier: ^2.0.16
-        version: 2.0.16
-      '@types/passport-jwt':
-        specifier: ^4.0.1
-        version: 4.0.1
-      '@types/passport-local':
-        specifier: ^1.0.38
-        version: 1.0.38
       '@types/swagger-ui-express':
         specifier: ^4.1.8
         version: 4.1.8
-      tsx:
-        specifier: ^4.19.3
-        version: 4.20.5
 
   apps/e2e:
     devDependencies:
@@ -312,7 +271,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/logger
       '@playwright/test':
-        specifier: ^1.40.0
+        specifier: ^1.51.1
         version: 1.55.0
       '@types/dotenv':
         specifier: ^8.2.3
@@ -348,9 +307,6 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
     devDependencies:
-      '@types/node':
-        specifier: ^20.0.0
-        version: 20.19.13
       '@types/react':
         specifier: ^18.3.0
         version: 18.3.24
@@ -361,7 +317,7 @@ importers:
         specifier: ^10.4.20
         version: 10.4.21(postcss@8.5.6)
       eslint:
-        specifier: ^8.0.0
+        specifier: ^8.57.0
         version: 8.57.1
       eslint-config-next:
         specifier: ^14.2.5
@@ -369,15 +325,9 @@ importers:
       postcss:
         specifier: ^8.4.47
         version: 8.5.6
-      rimraf:
-        specifier: ^5.0.0
-        version: 5.0.10
       tailwindcss:
         specifier: ^3.4.13
-        version: 3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.2))
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.2
+        version: 3.4.17(ts-node@10.9.2(@types/node@24.3.1)(typescript@5.9.2))
 
   apps/worker:
     dependencies:
@@ -387,10 +337,6 @@ importers:
       bullmq:
         specifier: ^5.58.5
         version: 5.58.5
-    devDependencies:
-      '@types/node':
-        specifier: ^20.19.13
-        version: 20.19.13
 
   infra/n8n:
     devDependencies:
@@ -429,7 +375,7 @@ importers:
         specifier: '>=3.4'
         version: 3.4.17(ts-node@10.9.2(@types/node@24.3.1)(typescript@5.9.2))
       typescript:
-        specifier: '>=5.4'
+        specifier: ^5.9.2
         version: 5.9.2
       vitest:
         specifier: '>=1.5'
@@ -455,7 +401,7 @@ importers:
         version: 11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core':
         specifier: ^11
-        version: 11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        version: 11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.6)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       bcryptjs:
         specifier: ^2.4.3
         version: 2.4.3
@@ -493,27 +439,6 @@ importers:
       '@connectwon/configs':
         specifier: workspace:*
         version: link:../configs
-      '@types/bcryptjs':
-        specifier: ^2.4.6
-        version: 2.4.6
-      '@types/ioredis':
-        specifier: ^5.0.0
-        version: 5.0.0
-      '@types/js-yaml':
-        specifier: ^4.0.9
-        version: 4.0.9
-      '@types/jsonwebtoken':
-        specifier: ^9.0.7
-        version: 9.0.10
-      '@types/nodemailer':
-        specifier: ^7.0.1
-        version: 7.0.1
-      rimraf:
-        specifier: ^6.0.1
-        version: 6.0.1
-      typescript:
-        specifier: ^5.5.4
-        version: 5.9.2
 
   packages/database:
     dependencies:
@@ -523,25 +448,16 @@ importers:
       '@connectwon/logger':
         specifier: workspace:*
         version: link:../logger
+      '@prisma/client':
+        specifier: ^6.15.0
+        version: 6.15.0(prisma@6.15.0(typescript@5.9.2))(typescript@5.9.2)
       dotenv:
         specifier: ^17.2.2
         version: 17.2.2
     devDependencies:
-      '@prisma/client':
-        specifier: ^6.15.0
-        version: 6.15.0(prisma@6.15.0(typescript@5.9.2))(typescript@5.9.2)
       prisma:
         specifier: ^6.15.0
         version: 6.15.0(typescript@5.9.2)
-      rimraf:
-        specifier: ^6.0.0
-        version: 6.0.1
-      tsx:
-        specifier: ^4.19.3
-        version: 4.20.5
-      typescript:
-        specifier: ^5.5.0
-        version: 5.9.2
 
   packages/logger:
     dependencies:
@@ -549,32 +465,16 @@ importers:
         specifier: ^2.7.0
         version: 2.7.0
       winston:
-        specifier: ^3.13.0
+        specifier: ^3.17.0
         version: 3.17.0
       winston-daily-rotate-file:
-        specifier: ^4.7.1
-        version: 4.7.1(winston@3.17.0)
-    devDependencies:
-      rimraf:
-        specifier: ^6.0.0
-        version: 6.0.1
-      typescript:
-        specifier: ^5.5.0
-        version: 5.9.2
+        specifier: ^5.0.0
+        version: 5.0.0(winston@3.17.0)
 
   packages/nest-kit:
     dependencies:
-      '@nestjs/common':
-        specifier: ^11.1.6
-        version: 11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core':
-        specifier: ^11.1.6
-        version: 11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/swagger':
-        specifier: ^11.2.0
-        version: 11.2.0(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)
       '@tanstack/react-query':
-        specifier: ^5.87.4
+        specifier: ^5.0.0
         version: 5.87.4(react@18.3.1)
       next:
         specifier: '>=14'
@@ -595,6 +495,15 @@ importers:
         specifier: ^3.23.8
         version: 3.25.76
     devDependencies:
+      '@nestjs/common':
+        specifier: ^11.1.6
+        version: 11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core':
+        specifier: ^11.1.6
+        version: 11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.6)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/swagger':
+        specifier: ^11.2.0
+        version: 11.2.0(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6)(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)
       '@types/nodemailer':
         specifier: ^7.0.1
         version: 7.0.1
@@ -614,12 +523,6 @@ importers:
       '@connectwon/configs':
         specifier: workspace:*
         version: link:../configs
-      rimraf:
-        specifier: ^6.0.0
-        version: 6.0.1
-      typescript:
-        specifier: ^5.5.0
-        version: 5.9.2
 
   packages/ui:
     dependencies:
@@ -645,15 +548,9 @@ importers:
       '@types/recharts':
         specifier: ^2.0.1
         version: 2.0.1(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(redux@5.0.1)
-      rimraf:
-        specifier: ^6.0.0
-        version: 6.0.1
       tailwindcss:
         specifier: ^3.4.13
         version: 3.4.17(ts-node@10.9.2(@types/node@24.3.1)(typescript@5.9.2))
-      typescript:
-        specifier: ^5.4.0
-        version: 5.9.2
 
 packages:
 
@@ -1754,10 +1651,6 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@colors/colors@1.5.0':
-    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
-    engines: {node: '>=0.1.90'}
-
   '@colors/colors@1.6.0':
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
     engines: {node: '>=0.1.90'}
@@ -2142,7 +2035,7 @@ packages:
     resolution: {integrity: sha512-j1a5VstaK5KQy8Mu8cHmuQvN1Zc62TbLhjJxwHvKPPKEoowSF6h/0UdOpA9DNdWZ+9Inq73+puRq1df6OJ8Sag==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^24.3.1
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -2151,7 +2044,7 @@ packages:
     resolution: {integrity: sha512-NyDSjPqhSvpZEMZrLCYUquWNl+XC/moEcVFqS55IEYIYsY0a1cUCevSqk7ctOlnm/RaSBU5psFryNlxcmGrjaA==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^24.3.1
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -2160,7 +2053,7 @@ packages:
     resolution: {integrity: sha512-Oau4yL24d2B5IL4ma4UpbQigkVhzPDXLoqy1ggK4gnHg/stmkffJE4oOXHXF3uz0UEpywG68KcyXsyYpA1Re/Q==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^24.3.1
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -2173,7 +2066,7 @@ packages:
     resolution: {integrity: sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^24.3.1
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -2336,7 +2229,7 @@ packages:
       html-to-text: ^9.0.5
       ignore: ^5.2.0
       interface-datastore: ^8.2.11
-      ioredis: ^5.3.2
+      ioredis: ^5.7.0
       it-all: ^3.0.4
       jsdom: '*'
       jsonwebtoken: ^9.0.2
@@ -2736,7 +2629,7 @@ packages:
       '@sentry/node': ^7.87.0
       better-sqlite3: ^7.1.2 || ^8.0.0 || ^9.0.0
       hdb-pool: ^0.1.6
-      ioredis: ^5.0.4
+      ioredis: ^5.7.0
       mongodb: ^5.8.0
       mssql: ^9.1.1 || ^10.0.1
       mysql2: ^2.2.5 || ^3.0.1
@@ -2821,7 +2714,7 @@ packages:
     peerDependencies:
       '@nestjs/common': ^10.0.0 || ^11.0.0
       '@nestjs/core': ^10.0.0 || ^11.0.0
-      bullmq: ^3.0.0 || ^4.0.0 || ^5.0.0
+      bullmq: ^5.58.5
 
   '@nestjs/common@11.1.6':
     resolution: {integrity: sha512-krKwLLcFmeuKDqngG2N/RuZHCs2ycsKcxWIDgcm7i1lf3sQ0iG03ci+DsP/r3FcT/eJDFsIHnKtNta2LIi7PzQ==}
@@ -2872,6 +2765,12 @@ packages:
         optional: true
       class-validator:
         optional: true
+
+  '@nestjs/platform-express@11.1.6':
+    resolution: {integrity: sha512-HErwPmKnk+loTq8qzu1up+k7FC6Kqa8x6lJ4cDw77KnTxLzsCaPt+jBvOq6UfICmfqcqCCf3dKXg+aObQp+kIQ==}
+    peerDependencies:
+      '@nestjs/common': ^11.0.0
+      '@nestjs/core': ^11.0.0
 
   '@nestjs/swagger@11.2.0':
     resolution: {integrity: sha512-5wolt8GmpNcrQv34tIPUtPoV1EeFbCetm40Ij3+M0FNNnf2RJ3FyWfuQvI8SBlcJyfaounYVTKzKHreFXsUyOg==}
@@ -3086,7 +2985,7 @@ packages:
   '@phenomnomnominal/tsquery@5.0.1':
     resolution: {integrity: sha512-3nVv+e2FQwsW8Aw6qTU6f+1rfcJ3hrcnvH/mu9i8YhxO+9sqbOfpL8m6PbET5+xKOlz/VSbp0RoYWYCtIsnmuA==}
     peerDependencies:
-      typescript: ^3 || ^4 || ^5
+      typescript: ^5.9.2
 
   '@pinecone-database/pinecone@2.1.0':
     resolution: {integrity: sha512-sbU5+FZ2yhG+tJYwEochoZei5988OLWZyM2aT4wenWc6sbKGV69Jm9Yl4yix10NNglzfksF9avkte1a0/k7x5Q==}
@@ -3121,7 +3020,7 @@ packages:
     engines: {node: '>=18.18'}
     peerDependencies:
       prisma: '*'
-      typescript: '>=5.1.0'
+      typescript: ^5.9.2
     peerDependenciesMeta:
       prisma:
         optional: true
@@ -3180,7 +3079,7 @@ packages:
     resolution: {integrity: sha512-YiX/IskbRCoAY2ujyPDI6FBcO0ygAS4pgkGaJ7DcrJFh4SZV2XHs+u0KM7mO72RWJn1eJQFF2PQwxG+401xxJg==}
     engines: {node: '>=18.0.0', pnpm: '>=8'}
     peerDependencies:
-      typescript: '>=4.7'
+      typescript: ^5.9.2
 
   '@qdrant/openapi-typescript-fetch@1.2.6':
     resolution: {integrity: sha512-oQG/FejNpItrxRHoyctYvT3rwGZOnK4jr3JdppO/c78ktDvkWiPXPHNsrDf33K9sZdRb6PR7gi4noIapu5q4HA==}
@@ -3191,12 +3090,6 @@ packages:
     peerDependencies:
       '@redis/client': ^1.0.0
 
-  '@redis/bloom@5.8.2':
-    resolution: {integrity: sha512-855DR0ChetZLarblio5eM0yLwxA9Dqq50t8StXKp5bAtLT0G+rZ+eRzzqxl37sPqQKjUudSYypz55o6nNhbz0A==}
-    engines: {node: '>= 18'}
-    peerDependencies:
-      '@redis/client': ^5.8.2
-
   '@redis/client@1.5.13':
     resolution: {integrity: sha512-epkUM9D0Sdmt93/8Ozk43PNjLi36RZzG+d/T1Gdu5AI8jvghonTeLYV69WVWdilvFo+PYxbP0TZ0saMvr6nscQ==}
     engines: {node: '>=14'}
@@ -3204,10 +3097,6 @@ packages:
   '@redis/client@1.6.1':
     resolution: {integrity: sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==}
     engines: {node: '>=14'}
-
-  '@redis/client@5.8.2':
-    resolution: {integrity: sha512-WtMScno3+eBpTac1Uav2zugXEoXqaU23YznwvFgkPwBQVwEHTDgOG7uEAObtZ/Nyn8SmAMbqkEubJaMOvnqdsQ==}
-    engines: {node: '>= 18'}
 
   '@redis/graph@1.1.1':
     resolution: {integrity: sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==}
@@ -3224,12 +3113,6 @@ packages:
     peerDependencies:
       '@redis/client': ^1.0.0
 
-  '@redis/json@5.8.2':
-    resolution: {integrity: sha512-uxpVfas3I0LccBX9rIfDgJ0dBrUa3+0Gc8sEwmQQH0vHi7C1Rx1Qn8Nv1QWz5bohoeIXMICFZRcyDONvum2l/w==}
-    engines: {node: '>= 18'}
-    peerDependencies:
-      '@redis/client': ^5.8.2
-
   '@redis/search@1.1.6':
     resolution: {integrity: sha512-mZXCxbTYKBQ3M2lZnEddwEAks0Kc7nauire8q20oA0oA/LoA+E/b5Y5KZn232ztPb1FkIGqo12vh3Lf+Vw5iTw==}
     peerDependencies:
@@ -3240,12 +3123,6 @@ packages:
     peerDependencies:
       '@redis/client': ^1.0.0
 
-  '@redis/search@5.8.2':
-    resolution: {integrity: sha512-cNv7HlgayavCBXqPXgaS97DRPVWFznuzsAmmuemi2TMCx5scwLiP50TeZvUS06h/MG96YNPe6A0Zt57yayfxwA==}
-    engines: {node: '>= 18'}
-    peerDependencies:
-      '@redis/client': ^5.8.2
-
   '@redis/time-series@1.0.5':
     resolution: {integrity: sha512-IFjIgTusQym2B5IZJG3XKr5llka7ey84fw/NOYqESP5WUfQs9zz1ww/9+qoz4ka/S6KcGBodzlCeZ5UImKbscg==}
     peerDependencies:
@@ -3255,12 +3132,6 @@ packages:
     resolution: {integrity: sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==}
     peerDependencies:
       '@redis/client': ^1.0.0
-
-  '@redis/time-series@5.8.2':
-    resolution: {integrity: sha512-g2NlHM07fK8H4k+613NBsk3y70R2JIM2dPMSkhIjl2Z17SYvaYKdusz85d7VYOrZBWtDrHV/WD2E3vGu+zni8A==}
-    engines: {node: '>= 18'}
-    peerDependencies:
-      '@redis/client': ^5.8.2
 
   '@reduxjs/toolkit@2.9.0':
     resolution: {integrity: sha512-fSfQlSRu9Z5yBkvsNhYF2rPS8cGXn/TZVrlwN1948QyZ8xMZ0JvP50S2acZNaf+o63u6aEeMjipFyksjIcWrog==}
@@ -4031,7 +3902,7 @@ packages:
   '@ts-rest/core@3.52.1':
     resolution: {integrity: sha512-tAjz7Kxq/grJodcTA1Anop4AVRDlD40fkksEV5Mmal88VoZeRKAG8oMHsDwdwPZz+B/zgnz0q2sF+cm5M7Bc7g==}
     peerDependencies:
-      '@types/node': ^18.18.7 || >=20.8.4
+      '@types/node': ^24.3.1
       zod: ^3.22.3
     peerDependenciesMeta:
       '@types/node':
@@ -4090,9 +3961,6 @@ packages:
   '@types/cli-progress@3.11.6':
     resolution: {integrity: sha512-cE3+jb9WRlu+uOSAugewNpITJDt1VF8dHOopPO4IABFc3SXYL5WE/+PTz/FCdZRRfIujiWW3n3aMbv1eIGVRWA==}
 
-  '@types/compression@1.8.1':
-    resolution: {integrity: sha512-kCFuWS0ebDbmxs0AXYn6e2r2nrGAb5KwQhknjSPSPgJcGd8+HVSILlUyFhGqML2gk39HcG7D1ydW9/qpYkN00Q==}
-
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
@@ -4145,9 +4013,6 @@ packages:
   '@types/express-serve-static-core@4.19.6':
     resolution: {integrity: sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==}
 
-  '@types/express-session@1.18.2':
-    resolution: {integrity: sha512-k+I0BxwVXsnEU2hV77cCobC08kIsn4y44C3gC0b46uxZVMaXA04lSPgRLR/bSL2w0t0ShJiG8o4jPzRG/nscFg==}
-
   '@types/express@4.17.23':
     resolution: {integrity: sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==}
 
@@ -4157,9 +4022,6 @@ packages:
   '@types/ioredis@5.0.0':
     resolution: {integrity: sha512-zJbJ3FVE17CNl5KXzdeSPtdltc4tMT3TzC6fxQS0sQngkbFZ6h+0uTafsRqu+eSLIugf6Yb0Ea0SUuRr42Nk9g==}
     deprecated: This is a stub types definition. ioredis provides its own type definitions, so you do not need this installed.
-
-  '@types/js-yaml@4.0.9':
-    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -4191,44 +4053,14 @@ packages:
   '@types/node-fetch@2.6.13':
     resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
 
-  '@types/node@12.20.55':
-    resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
-
-  '@types/node@18.19.124':
-    resolution: {integrity: sha512-hY4YWZFLs3ku6D2Gqo3RchTd9VRCcrjqp/I0mmohYeUVA5Y8eCXKJEasHxLAJVZRJuQogfd1GiJ9lgogBgKeuQ==}
-
-  '@types/node@20.19.13':
-    resolution: {integrity: sha512-yCAeZl7a0DxgNVteXFHt9+uyFbqXGy/ShC4BlcHkoE0AfGXYv/BUiplV72DjMYXHDBXFjhvr6DD1NiRVfB4j8g==}
-
   '@types/node@24.3.1':
     resolution: {integrity: sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==}
 
   '@types/nodemailer@7.0.1':
     resolution: {integrity: sha512-UfHAghPmGZVzaL8x9y+mKZMWyHC399+iq0MOmya5tIyenWX3lcdSb60vOmp0DocR6gCDTYTozv/ULQnREyyjkg==}
 
-  '@types/oauth@0.9.6':
-    resolution: {integrity: sha512-H9TRCVKBNOhZZmyHLqFt9drPM9l+ShWiqqJijU1B8P3DX3ub84NjxDuy+Hjrz+fEca5Kwip3qPMKNyiLgNJtIA==}
-
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
-
-  '@types/passport-google-oauth20@2.0.16':
-    resolution: {integrity: sha512-ayXK2CJ7uVieqhYOc6k/pIr5pcQxOLB6kBev+QUGS7oEZeTgIs1odDobXRqgfBPvXzl0wXCQHftV5220czZCPA==}
-
-  '@types/passport-jwt@4.0.1':
-    resolution: {integrity: sha512-Y0Ykz6nWP4jpxgEUYq8NoVZeCQPo1ZndJLfapI249g1jHChvRfZRO/LS3tqu26YgAS/laI1qx98sYGz0IalRXQ==}
-
-  '@types/passport-local@1.0.38':
-    resolution: {integrity: sha512-nsrW4A963lYE7lNTv9cr5WmiUD1ibYJvWrpE13oxApFsRt77b0RdtZvKbCdNIY4v/QZ6TRQWaDDEwV1kCTmcXg==}
-
-  '@types/passport-oauth2@1.8.0':
-    resolution: {integrity: sha512-6//z+4orIOy/g3zx17HyQ71GSRK4bs7Sb+zFasRoc2xzlv7ZCJ+vkDBYFci8U6HY+or6Zy7ajf4mz4rK7nsWJQ==}
-
-  '@types/passport-strategy@0.2.38':
-    resolution: {integrity: sha512-GC6eMqqojOooq993Tmnmp7AUTbbQSgilyvpCYQjT+H6JfG/g6RGc7nXEniZlp0zyKJ0WUdOiZWLBZft9Yug1uA==}
-
-  '@types/passport@1.0.17':
-    resolution: {integrity: sha512-aciLyx+wDwT2t2/kJGJR2AEeBz0nJU4WuRX04Wu9Dqc5lSUtwu0WERPHYsLhF9PtseiAMPBGNUOtFjxZ56prsg==}
 
   '@types/phoenix@1.6.6':
     resolution: {integrity: sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==}
@@ -4320,20 +4152,20 @@ packages:
     peerDependencies:
       '@typescript-eslint/parser': ^8.42.0
       eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: ^5.9.2
 
   '@typescript-eslint/parser@8.42.0':
     resolution: {integrity: sha512-r1XG74QgShUgXph1BYseJ+KZd17bKQib/yF3SR+demvytiRXrwd12Blnz5eYGm8tXaeRdd4x88MlfwldHoudGg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: ^5.9.2
 
   '@typescript-eslint/project-service@8.42.0':
     resolution: {integrity: sha512-vfVpLHAhbPjilrabtOSNcUDmBboQNrJUiNAGoImkZKnMjs2TIcWG33s4Ds0wY3/50aZmTMqJa6PiwkwezaAklg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: ^5.9.2
 
   '@typescript-eslint/scope-manager@8.42.0':
     resolution: {integrity: sha512-51+x9o78NBAVgQzOPd17DkNTnIzJ8T/O2dmMBLoK9qbY0Gm52XJcdJcCl18ExBMiHo6jPMErUQWUv5RLE51zJw==}
@@ -4343,14 +4175,14 @@ packages:
     resolution: {integrity: sha512-kHeFUOdwAJfUmYKjR3CLgZSglGHjbNTi1H8sTYRYV2xX6eNz4RyJ2LIgsDLKf8Yi0/GL1WZAC/DgZBeBft8QAQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: ^5.9.2
 
   '@typescript-eslint/type-utils@8.42.0':
     resolution: {integrity: sha512-9KChw92sbPTYVFw3JLRH1ockhyR3zqqn9lQXol3/YbI6jVxzWoGcT3AsAW0mu1MY0gYtsXnUGV/AKpkAj5tVlQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: ^5.9.2
 
   '@typescript-eslint/types@8.42.0':
     resolution: {integrity: sha512-LdtAWMiFmbRLNP7JNeY0SqEtJvGMYSzfiWBSmx+VSZ1CH+1zyl8Mmw1TT39OrtsRvIYShjJWzTDMPWZJCpwBlw==}
@@ -4360,14 +4192,14 @@ packages:
     resolution: {integrity: sha512-ku/uYtT4QXY8sl9EDJETD27o3Ewdi72hcXg1ah/kkUgBvAYHLwj2ofswFFNXS+FL5G+AGkxBtvGt8pFBHKlHsQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: ^5.9.2
 
   '@typescript-eslint/utils@8.42.0':
     resolution: {integrity: sha512-JnIzu7H3RH5BrKC4NoZqRfmjqCIS1u3hGZltDYJgkVdqAezl4L9d1ZLw+36huCujtSBSAirGINF/S4UxOcR+/g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: ^5.9.2
 
   '@typescript-eslint/visitor-keys@8.42.0':
     resolution: {integrity: sha512-3WbiuzoEowaEn8RSnhJBrxSwX8ULYE9CXaPepS2C2W3NSA5NNIvBaslpBSBElPq0UGr0xVJlXFWOAKIkyylydQ==}
@@ -4518,7 +4350,7 @@ packages:
   '@xata.io/client@0.28.4':
     resolution: {integrity: sha512-B02WHIA/ViHya84XvH6JCo13rd5h4S5vVyY2aYi6fIcjDIbCpsSLJ4oGWpdodovRYeAZy9Go4OhdyZwMIRC4BQ==}
     peerDependencies:
-      typescript: '>=4.5'
+      typescript: ^5.9.2
 
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
@@ -4547,6 +4379,10 @@ packages:
 
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
   acorn-jsx@5.3.2:
@@ -4910,10 +4746,6 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  base64url@3.0.1:
-    resolution: {integrity: sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==}
-    engines: {node: '>=6.0.0'}
-
   basic-auth@2.0.1:
     resolution: {integrity: sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==}
     engines: {node: '>= 0.8'}
@@ -4982,6 +4814,10 @@ packages:
   body-parser@1.20.3:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  body-parser@2.2.0:
+    resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
+    engines: {node: '>=18'}
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
@@ -5367,10 +5203,6 @@ packages:
     resolution: {integrity: sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==}
     engines: {node: '>= 0.8.0'}
 
-  compression@1.8.1:
-    resolution: {integrity: sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==}
-    engines: {node: '>= 0.8.0'}
-
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -5393,13 +5225,6 @@ packages:
   confusing-browser-globals@1.0.11:
     resolution: {integrity: sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==}
 
-  connect-redis@9.0.0:
-    resolution: {integrity: sha512-QwzyvUePTMvEzG1hy45gZYw3X3YHrjmEdSkayURlcZft7hqadQ3X39wYkmCqblK2rGlw+XItELYt6GnyG6DEIQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      express-session: '>=1'
-      redis: '>=5'
-
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
@@ -5412,6 +5237,10 @@ packages:
 
   content-disposition@0.5.4:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
+    engines: {node: '>= 0.6'}
+
+  content-disposition@1.0.0:
+    resolution: {integrity: sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==}
     engines: {node: '>= 0.6'}
 
   content-type@1.0.5:
@@ -5435,8 +5264,9 @@ packages:
   cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
 
-  cookie-signature@1.0.7:
-    resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
 
   cookie@0.4.1:
     resolution: {integrity: sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==}
@@ -5475,9 +5305,9 @@ packages:
     resolution: {integrity: sha512-tJ1w35ZRUiM5FeTzT7DtYWAFFv37ZLqSRkGi2oeCK1gPhvaWjkAtfXvLmvE1pRfxxp9aQo6ba/Pvg1dKj05D4g==}
     engines: {node: '>=v18'}
     peerDependencies:
-      '@types/node': '*'
+      '@types/node': ^24.3.1
       cosmiconfig: '>=9'
-      typescript: '>=5'
+      typescript: ^5.9.2
 
   cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
@@ -5487,7 +5317,7 @@ packages:
     resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
     engines: {node: '>=14'}
     peerDependencies:
-      typescript: '>=4.9.5'
+      typescript: ^5.9.2
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -6084,7 +5914,7 @@ packages:
     resolution: {integrity: sha512-mP/NmYtDBsKlKIOBnH+CW+pYeyR3wBhE+26DAqQ0/aRtEBeTEjgY2wAFUugUELkTLmrX6PpuMSSTpOhz7j9kdQ==}
     peerDependencies:
       eslint: ^7.23.0 || ^8.0.0
-      typescript: '>=3.3.1'
+      typescript: ^5.9.2
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -6330,16 +6160,6 @@ packages:
     peerDependencies:
       express: 4 || 5 || ^5.0.0-beta.1
 
-  express-rate-limit@8.1.0:
-    resolution: {integrity: sha512-4nLnATuKupnmwqiJc27b4dCFmB/T60ExgmtDD7waf4LdrbJ8CPZzZRHYErDYNhoz+ql8fUdYwM/opf90PoPAQA==}
-    engines: {node: '>= 16'}
-    peerDependencies:
-      express: '>= 4.11'
-
-  express-session@1.18.2:
-    resolution: {integrity: sha512-SZjssGQC7TzTs9rpPDuUrR23GNZ9+2+IkA/+IJWmvQilTr5OSliEHGF+D9scbIpdC6yGtTI0/VhaHoVes2AN/A==}
-    engines: {node: '>= 0.8.0'}
-
   express@4.19.2:
     resolution: {integrity: sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==}
     engines: {node: '>= 0.10.0'}
@@ -6347,6 +6167,10 @@ packages:
   express@4.21.2:
     resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
     engines: {node: '>= 0.10.0'}
+
+  express@5.1.0:
+    resolution: {integrity: sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==}
+    engines: {node: '>= 18'}
 
   exsolve@1.0.7:
     resolution: {integrity: sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==}
@@ -6480,6 +6304,10 @@ packages:
     resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
     engines: {node: '>= 0.8'}
 
+  finalhandler@2.1.0:
+    resolution: {integrity: sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==}
+    engines: {node: '>= 0.8'}
+
   find-config@1.0.0:
     resolution: {integrity: sha512-Z+suHH+7LSE40WfUeZPIxSxypCWvrzdVc60xAjUShZeT5eMWM0/FQUduq3HjluyfAHWvC/aOBkT1pTZktyF/jg==}
     engines: {node: '>= 0.12'}
@@ -6587,6 +6415,10 @@ packages:
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   front-matter@4.0.2:
     resolution: {integrity: sha512-I8ZuJ/qG92NWX8i5x1Y8qyj3vizhXS31OxjKDu3LKP+7/qBgfIKValiZIEwoVoJKUHlhWtYrktkxV1XsX+pPlg==}
@@ -6995,6 +6827,10 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
+  iconv-lite@0.7.0:
+    resolution: {integrity: sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==}
+    engines: {node: '>=0.10.0'}
+
   ics@2.40.0:
     resolution: {integrity: sha512-PPkE9ij60sGhqdTxZZzsXQPB/TCXAB/dD3NqUf1I/GkbJzPeJHHMzaoMQiYAsm1pFaHRp2OIhFDgUBihkk8s/w==}
 
@@ -7078,10 +6914,6 @@ packages:
   interpret@1.4.0:
     resolution: {integrity: sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==}
     engines: {node: '>= 0.10'}
-
-  ioredis@5.3.2:
-    resolution: {integrity: sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==}
-    engines: {node: '>=12.22.0'}
 
   ioredis@5.7.0:
     resolution: {integrity: sha512-NUcA93i1lukyXU+riqEyPtSEkyFq8tX90uL659J+qpCZ3rEdViB/APC58oAhIh3+bJln2hzdlZbBZsGNrlsR8g==}
@@ -7223,6 +7055,9 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-property@1.0.2:
     resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
@@ -7539,7 +7374,7 @@ packages:
       handlebars: ^4.7.8
       html-to-text: ^9.0.5
       ignore: ^5.2.0
-      ioredis: ^5.3.2
+      ioredis: ^5.7.0
       jsdom: '*'
       mammoth: ^1.6.0
       mongodb: '>=5.2.0'
@@ -7944,6 +7779,10 @@ packages:
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
 
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
@@ -7972,6 +7811,10 @@ packages:
 
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.1:
+    resolution: {integrity: sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==}
     engines: {node: '>= 0.6'}
 
   mime@1.6.0:
@@ -8205,7 +8048,7 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
-      typescript: '>= 4.8.x'
+      typescript: ^5.9.2
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -8214,6 +8057,10 @@ packages:
     resolution: {integrity: sha512-VzGiVigcG9zUAoCNU+xShztrlr1auZOlurXynNvO9GiWD1/mTBbUljOKY+qMeazBqXgRnjzeEgJI/wyjJUHg9A==}
     engines: {node: '>= 6.0.0'}
     deprecated: Multer 1.x is impacted by a number of vulnerabilities, which have been patched in 2.x. You should upgrade to the latest 2.x version.
+
+  multer@2.0.2:
+    resolution: {integrity: sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==}
+    engines: {node: '>= 10.16.0'}
 
   mustache@4.2.0:
     resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
@@ -8299,6 +8146,10 @@ packages:
 
   negotiator@0.6.4:
     resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
+    engines: {node: '>= 0.6'}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
   neo-async@2.6.2:
@@ -8472,16 +8323,9 @@ packages:
   oauth-1.0a@2.2.6:
     resolution: {integrity: sha512-6bkxv3N4Gu5lty4viIcIAnq5GbxECviMBeKR3WX/q87SPQ8E8aursPZUtsXDnxCs787af09WPRBLqYrf/lwoYQ==}
 
-  oauth@0.10.2:
-    resolution: {integrity: sha512-JtFnB+8nxDEXgNyniwz573xxbKSOu3R8D40xQKqcjwJ2CDkYqUDI53o6IuzDJBx60Z8VKCm271+t8iFjakrl8Q==}
-
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
-
-  object-hash@2.2.0:
-    resolution: {integrity: sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==}
-    engines: {node: '>= 6'}
 
   object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
@@ -8753,29 +8597,6 @@ packages:
   pascal-case@3.1.2:
     resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
 
-  passport-google-oauth20@2.0.0:
-    resolution: {integrity: sha512-KSk6IJ15RoxuGq7D1UKK/8qKhNfzbLeLrG3gkLZ7p4A6DBCcv7xpyQwuXtWdpyR0+E0mwkpjY1VfPOhxQrKzdQ==}
-    engines: {node: '>= 0.4.0'}
-
-  passport-jwt@4.0.1:
-    resolution: {integrity: sha512-UCKMDYhNuGOBE9/9Ycuoyh7vP6jpeTp/+sfMJl7nLff/t6dps+iaeE0hhNkKN8/HZHcJ7lCdOyDxHdDoxoSvdQ==}
-
-  passport-local@1.0.0:
-    resolution: {integrity: sha512-9wCE6qKznvf9mQYYbgJ3sVOHmCWoUNMVFoZzNoznmISbhnNNPhN9xfY3sLmScHMetEJeoY7CXwfhCe7argfQow==}
-    engines: {node: '>= 0.4.0'}
-
-  passport-oauth2@1.8.0:
-    resolution: {integrity: sha512-cjsQbOrXIDE4P8nNb3FQRCCmJJ/utnFKEz2NX209f7KOHPoX18gF7gBzBbLLsj2/je4KrgiwLLGjf0lm9rtTBA==}
-    engines: {node: '>= 0.4.0'}
-
-  passport-strategy@1.0.0:
-    resolution: {integrity: sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==}
-    engines: {node: '>= 0.4.0'}
-
-  passport@0.7.0:
-    resolution: {integrity: sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==}
-    engines: {node: '>= 0.4.0'}
-
   password-prompt@1.1.3:
     resolution: {integrity: sha512-HkrjG2aJlvF0t2BMH0e2LB/EHf3Lcq3fNMzy4GYHcQblAvOl+QQji1Lx7WRBMqpVK8p+KR7bCg7oqAMXtdgqyw==}
 
@@ -8832,9 +8653,6 @@ packages:
   pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
-
-  pause@0.0.1:
-    resolution: {integrity: sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg==}
 
   pdf-parse@1.1.1:
     resolution: {integrity: sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==}
@@ -9069,7 +8887,7 @@ packages:
     engines: {node: '>=18.18'}
     hasBin: true
     peerDependencies:
-      typescript: '>=5.1.0'
+      typescript: ^5.9.2
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -9208,6 +9026,10 @@ packages:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
     engines: {node: '>= 0.8'}
 
+  raw-body@3.0.1:
+    resolution: {integrity: sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==}
+    engines: {node: '>= 0.10'}
+
   rc9@2.1.2:
     resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
 
@@ -9323,10 +9145,6 @@ packages:
   redis@4.7.1:
     resolution: {integrity: sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==}
 
-  redis@5.8.2:
-    resolution: {integrity: sha512-31vunZj07++Y1vcFGcnNWEf5jPoTkGARgfWI4+Tk55vdwHxhAvug8VEtW7Cx+/h47NuJTEg/JL77zAwC6E0OeA==}
-    engines: {node: '>= 18'}
-
   redux-thunk@3.1.0:
     resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
     peerDependencies:
@@ -9334,6 +9152,9 @@ packages:
 
   redux@5.0.1:
     resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
+
+  reflect-metadata@0.1.14:
+    resolution: {integrity: sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==}
 
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
@@ -9466,10 +9287,6 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
-  rimraf@5.0.10:
-    resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
-    hasBin: true
-
   rimraf@6.0.1:
     resolution: {integrity: sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==}
     engines: {node: 20 || >=22}
@@ -9482,6 +9299,10 @@ packages:
     resolution: {integrity: sha512-78E9voJHwnXQMiQdiqswVLZwJIzdBKJ1GdI5Zx6XwoFKUIk09/sSrr+05QFzvYb8q6Y9pPV45zzDuYa3907TZA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
 
   rrule@2.8.1:
     resolution: {integrity: sha512-hM3dHSBMeaJ0Ktp7W38BJZ7O1zOgaFEsn41PDk+yHoEtfLV+PoJt9E9xAlZiWgf/iqEqionN0ebHFZIDAp+iGw==}
@@ -9587,6 +9408,10 @@ packages:
     resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
     engines: {node: '>= 0.8.0'}
 
+  send@1.2.0:
+    resolution: {integrity: sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==}
+    engines: {node: '>= 18'}
+
   sentence-case@3.0.4:
     resolution: {integrity: sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==}
 
@@ -9603,6 +9428,10 @@ packages:
   serve-static@1.16.2:
     resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
     engines: {node: '>= 0.8.0'}
+
+  serve-static@2.2.0:
+    resolution: {integrity: sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==}
+    engines: {node: '>= 18'}
 
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
@@ -10215,7 +10044,7 @@ packages:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
     engines: {node: '>=18.12'}
     peerDependencies:
-      typescript: '>=4.8.4'
+      typescript: ^5.9.2
 
   ts-ics@1.6.8:
     resolution: {integrity: sha512-Ze35cvu1UDt6jXIXYIMYjXHgBtlQjThRWN6YfES1cRUN6MX4V0G28H1nuKhY0XfZwFlYkmf+p22vzg8DpV3p9A==}
@@ -10233,8 +10062,8 @@ packages:
     peerDependencies:
       '@swc/core': '>=1.2.50'
       '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
+      '@types/node': ^24.3.1
+      typescript: ^5.9.2
     peerDependenciesMeta:
       '@swc/core':
         optional: true
@@ -10254,7 +10083,7 @@ packages:
     engines: {node: ^18 || >=20}
     hasBin: true
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: ^5.9.2
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -10317,6 +10146,10 @@ packages:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
 
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+
   type-of-is@3.5.1:
     resolution: {integrity: sha512-SOnx8xygcAh8lvDU2exnK2bomASfNjzB3Qz71s2tw9QnX8fkAo7aC+D0H7FV0HjRKj94CKV2Hi71kVkkO6nOxg==}
     engines: {node: '>=0.10.5'}
@@ -10351,12 +10184,7 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
-  typescript@5.8.3:
-    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
-    engines: {node: '>=14.17'}
-    hasBin: true
+      typescript: ^5.9.2
 
   typescript@5.9.2:
     resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
@@ -10375,9 +10203,6 @@ packages:
     resolution: {integrity: sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==}
     engines: {node: '>= 0.8'}
 
-  uid2@0.0.4:
-    resolution: {integrity: sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA==}
-
   uid@2.0.2:
     resolution: {integrity: sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==}
     engines: {node: '>=8'}
@@ -10392,12 +10217,6 @@ packages:
 
   underscore@1.13.7:
     resolution: {integrity: sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==}
-
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   undici-types@7.10.0:
     resolution: {integrity: sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==}
@@ -10555,7 +10374,7 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
+      '@types/node': ^24.3.1
       jiti: '>=1.21.0'
       less: ^4.0.0
       lightningcss: ^1.21.0
@@ -10597,7 +10416,7 @@ packages:
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/debug': ^4.1.12
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@types/node': ^24.3.1
       '@vitest/browser': 3.2.4
       '@vitest/ui': 3.2.4
       happy-dom: '*'
@@ -10692,17 +10511,11 @@ packages:
     resolution: {integrity: sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==}
     engines: {node: '>=8'}
 
-  winston-daily-rotate-file@4.7.1:
-    resolution: {integrity: sha512-7LGPiYGBPNyGHLn9z33i96zx/bd71pjBn9tqQzO3I4Tayv94WPmBNwKC7CO1wPHdP9uvu+Md/1nr6VSH9h0iaA==}
-    engines: {node: '>=8'}
-    peerDependencies:
-      winston: ^3
-
   winston-daily-rotate-file@5.0.0:
     resolution: {integrity: sha512-JDjiXXkM5qvwY06733vf09I2wnMXpZEhxEVOSPenZMii+g7pcDcTBt2MRugnoi8BwVSuCT2jfRXBUy+n1Zz/Yw==}
     engines: {node: '>=8'}
     peerDependencies:
-      winston: ^3
+      winston: ^3.17.0
 
   winston-transport@4.9.0:
     resolution: {integrity: sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==}
@@ -10710,10 +10523,6 @@ packages:
 
   winston@3.17.0:
     resolution: {integrity: sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==}
-    engines: {node: '>= 12.0.0'}
-
-  winston@3.8.2:
-    resolution: {integrity: sha512-MsE1gRx1m5jdTTO9Ld/vND4krP2To+lgDoMEHGGa4HIlAUyXJtfc7CxQcGXVyz2IBpw5hbFkj2b/AtUdQwyRew==}
     engines: {node: '>= 12.0.0'}
 
   word-wrap@1.2.5:
@@ -10911,7 +10720,7 @@ snapshots:
 
   '@anthropic-ai/sdk@0.21.1(encoding@0.1.13)':
     dependencies:
-      '@types/node': 18.19.124
+      '@types/node': 24.3.1
       '@types/node-fetch': 2.6.13
       abort-controller: 3.0.0
       agentkeepalive: 4.6.0
@@ -13220,8 +13029,6 @@ snapshots:
       human-id: 4.1.1
       prettier: 2.8.8
 
-  '@colors/colors@1.5.0': {}
-
   '@colors/colors@1.6.0': {}
 
   '@commitlint/config-validator@19.8.1':
@@ -13698,66 +13505,7 @@ snapshots:
       - encoding
       - openai
 
-  '@langchain/community@0.2.2(607ef954e07105212e3a229fa0e4ebab)':
-    dependencies:
-      '@langchain/core': 0.2.0(openai@4.47.1(encoding@0.1.13))
-      '@langchain/openai': 0.0.33(encoding@0.1.13)(ws@8.14.2)
-      binary-extensions: 2.3.0
-      expr-eval: 2.0.2
-      flat: 5.0.2
-      js-yaml: 4.1.0
-      langchain: 0.2.2(@aws-sdk/client-s3@3.887.0)(@aws-sdk/credential-provider-node@3.535.0)(@azure/storage-blob@12.28.0)(@google-ai/generativelanguage@2.5.0(encoding@0.1.13))(@pinecone-database/pinecone@2.2.1)(@supabase/supabase-js@2.43.4)(@xata.io/client@0.28.4(typescript@5.9.2))(axios@1.6.7)(d3-dsv@2.0.0)(encoding@0.1.13)(epub2@3.0.2(ts-toolbelt@9.6.0))(fast-xml-parser@5.2.5)(handlebars@4.7.8)(html-to-text@9.0.5)(ignore@5.3.2)(ioredis@5.3.2)(jsdom@26.1.0)(mammoth@1.7.2)(openai@4.47.1(encoding@0.1.13))(pdf-parse@1.1.1)(playwright@1.55.0)(redis@4.6.12)(ws@8.14.2)
-      langsmith: 0.1.68(openai@4.47.1(encoding@0.1.13))
-      uuid: 9.0.1
-      zod: 3.25.76
-      zod-to-json-schema: 3.24.6(zod@3.25.76)
-    optionalDependencies:
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/client-bedrock-runtime': 3.535.0
-      '@aws-sdk/client-s3': 3.887.0
-      '@aws-sdk/credential-provider-node': 3.535.0
-      '@azure/storage-blob': 12.28.0
-      '@getzep/zep-js': 0.9.0
-      '@google-ai/generativelanguage': 2.5.0(encoding@0.1.13)
-      '@google-cloud/storage': 6.12.0(encoding@0.1.13)
-      '@huggingface/inference': 2.7.0
-      '@pinecone-database/pinecone': 2.2.1
-      '@qdrant/js-client-rest': 1.9.0(typescript@5.9.2)
-      '@smithy/eventstream-codec': 2.2.0
-      '@smithy/protocol-http': 3.3.0
-      '@smithy/signature-v4': 2.3.0
-      '@smithy/util-utf8': 2.3.0
-      '@supabase/postgrest-js': 1.15.2
-      '@supabase/supabase-js': 2.43.4
-      '@xata.io/client': 0.28.4(typescript@5.9.2)
-      cohere-ai: 7.10.1(encoding@0.1.13)
-      d3-dsv: 2.0.0
-      epub2: 3.0.2(ts-toolbelt@9.6.0)
-      google-auth-library: 8.9.0(encoding@0.1.13)
-      html-to-text: 9.0.5
-      ignore: 5.3.2
-      ioredis: 5.3.2
-      jsdom: 26.1.0
-      jsonwebtoken: 9.0.2
-      lodash: 4.17.21
-      mammoth: 1.7.2
-      mysql2: 3.9.7
-      pdf-parse: 1.1.1
-      pg: 8.11.3
-      playwright: 1.55.0
-      redis: 4.6.12
-      ws: 8.14.2
-    transitivePeerDependencies:
-      - '@gomomento/sdk-web'
-      - axios
-      - encoding
-      - fast-xml-parser
-      - handlebars
-      - openai
-      - peggy
-      - pyodide
-
-  '@langchain/community@0.2.2(aa2844e97b0f2d20793211e4fa3c4e54)':
+  '@langchain/community@0.2.2(8b4d0dd5e51a1bff0585c680b5a6468c)':
     dependencies:
       '@langchain/core': 0.2.0(openai@5.20.0(ws@8.14.2)(zod@3.22.4))
       '@langchain/openai': 0.0.33(encoding@0.1.13)(ws@8.14.2)
@@ -13765,7 +13513,7 @@ snapshots:
       expr-eval: 2.0.2
       flat: 5.0.2
       js-yaml: 4.1.0
-      langchain: 0.2.2(@aws-sdk/client-s3@3.887.0)(@aws-sdk/credential-provider-node@3.535.0)(@azure/storage-blob@12.28.0)(@google-ai/generativelanguage@2.5.0(encoding@0.1.13))(@pinecone-database/pinecone@2.1.0)(@supabase/supabase-js@2.43.4)(@xata.io/client@0.28.4(typescript@5.9.2))(axios@1.6.7)(d3-dsv@2.0.0)(encoding@0.1.13)(epub2@3.0.2(ts-toolbelt@9.6.0))(fast-xml-parser@5.2.5)(handlebars@4.7.8)(html-to-text@9.0.5)(ignore@5.3.2)(ioredis@5.3.2)(jsdom@26.1.0)(mammoth@1.7.2)(openai@5.20.0(ws@8.14.2)(zod@3.22.4))(pdf-parse@1.1.1)(playwright@1.55.0)(redis@4.6.12)(ws@8.14.2)
+      langchain: 0.2.2(@aws-sdk/client-s3@3.887.0)(@aws-sdk/credential-provider-node@3.535.0)(@azure/storage-blob@12.28.0)(@google-ai/generativelanguage@2.5.0(encoding@0.1.13))(@pinecone-database/pinecone@2.1.0)(@supabase/supabase-js@2.43.4)(@xata.io/client@0.28.4(typescript@5.9.2))(axios@1.6.7)(d3-dsv@2.0.0)(encoding@0.1.13)(epub2@3.0.2(ts-toolbelt@9.6.0))(fast-xml-parser@5.2.5)(handlebars@4.7.8)(html-to-text@9.0.5)(ignore@5.3.2)(ioredis@5.7.0)(jsdom@26.1.0)(mammoth@1.7.2)(openai@5.20.0(ws@8.14.2)(zod@3.22.4))(pdf-parse@1.1.1)(playwright@1.55.0)(redis@4.6.12)(ws@8.14.2)
       langsmith: 0.1.68(openai@5.20.0(ws@8.14.2)(zod@3.22.4))
       uuid: 9.0.1
       zod: 3.25.76
@@ -13795,7 +13543,66 @@ snapshots:
       google-auth-library: 8.9.0(encoding@0.1.13)
       html-to-text: 9.0.5
       ignore: 5.3.2
-      ioredis: 5.3.2
+      ioredis: 5.7.0
+      jsdom: 26.1.0
+      jsonwebtoken: 9.0.2
+      lodash: 4.17.21
+      mammoth: 1.7.2
+      mysql2: 3.9.7
+      pdf-parse: 1.1.1
+      pg: 8.11.3
+      playwright: 1.55.0
+      redis: 4.6.12
+      ws: 8.14.2
+    transitivePeerDependencies:
+      - '@gomomento/sdk-web'
+      - axios
+      - encoding
+      - fast-xml-parser
+      - handlebars
+      - openai
+      - peggy
+      - pyodide
+
+  '@langchain/community@0.2.2(d822633e396d3d43f67a8695ba237eda)':
+    dependencies:
+      '@langchain/core': 0.2.0(openai@4.47.1(encoding@0.1.13))
+      '@langchain/openai': 0.0.33(encoding@0.1.13)(ws@8.14.2)
+      binary-extensions: 2.3.0
+      expr-eval: 2.0.2
+      flat: 5.0.2
+      js-yaml: 4.1.0
+      langchain: 0.2.2(@aws-sdk/client-s3@3.887.0)(@aws-sdk/credential-provider-node@3.535.0)(@azure/storage-blob@12.28.0)(@google-ai/generativelanguage@2.5.0(encoding@0.1.13))(@pinecone-database/pinecone@2.2.1)(@supabase/supabase-js@2.43.4)(@xata.io/client@0.28.4(typescript@5.9.2))(axios@1.6.7)(d3-dsv@2.0.0)(encoding@0.1.13)(epub2@3.0.2(ts-toolbelt@9.6.0))(fast-xml-parser@5.2.5)(handlebars@4.7.8)(html-to-text@9.0.5)(ignore@5.3.2)(ioredis@5.7.0)(jsdom@26.1.0)(mammoth@1.7.2)(openai@4.47.1(encoding@0.1.13))(pdf-parse@1.1.1)(playwright@1.55.0)(redis@4.6.12)(ws@8.14.2)
+      langsmith: 0.1.68(openai@4.47.1(encoding@0.1.13))
+      uuid: 9.0.1
+      zod: 3.25.76
+      zod-to-json-schema: 3.24.6(zod@3.25.76)
+    optionalDependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/client-bedrock-runtime': 3.535.0
+      '@aws-sdk/client-s3': 3.887.0
+      '@aws-sdk/credential-provider-node': 3.535.0
+      '@azure/storage-blob': 12.28.0
+      '@getzep/zep-js': 0.9.0
+      '@google-ai/generativelanguage': 2.5.0(encoding@0.1.13)
+      '@google-cloud/storage': 6.12.0(encoding@0.1.13)
+      '@huggingface/inference': 2.7.0
+      '@pinecone-database/pinecone': 2.2.1
+      '@qdrant/js-client-rest': 1.9.0(typescript@5.9.2)
+      '@smithy/eventstream-codec': 2.2.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/signature-v4': 2.3.0
+      '@smithy/util-utf8': 2.3.0
+      '@supabase/postgrest-js': 1.15.2
+      '@supabase/supabase-js': 2.43.4
+      '@xata.io/client': 0.28.4(typescript@5.9.2)
+      cohere-ai: 7.10.1(encoding@0.1.13)
+      d3-dsv: 2.0.0
+      epub2: 3.0.2(ts-toolbelt@9.6.0)
+      google-auth-library: 8.9.0(encoding@0.1.13)
+      html-to-text: 9.0.5
+      ignore: 5.3.2
+      ioredis: 5.7.0
       jsdom: 26.1.0
       jsonwebtoken: 9.0.2
       lodash: 4.17.21
@@ -13993,7 +13800,7 @@ snapshots:
   '@manypkg/find-root@1.1.0':
     dependencies:
       '@babel/runtime': 7.28.4
-      '@types/node': 12.20.55
+      '@types/node': 24.3.1
       find-up: 4.1.0
       fs-extra: 8.1.0
 
@@ -14068,7 +13875,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@n8n/n8n-nodes-langchain@1.44.0(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.887.0)(@azure/storage-blob@12.28.0)(@google-cloud/storage@6.12.0(encoding@0.1.13))(@sentry/node@7.87.0)(@smithy/eventstream-codec@2.2.0)(@smithy/protocol-http@3.3.0)(@smithy/signature-v4@2.3.0)(@smithy/util-utf8@2.3.0)(@supabase/postgrest-js@1.15.2)(asn1.js@5.4.1)(axios@1.6.7)(date-fns@4.1.0)(encoding@0.1.13)(fast-xml-parser@5.2.5)(gcp-metadata@5.3.0(encoding@0.1.13))(google-auth-library@8.9.0(encoding@0.1.13))(handlebars@4.7.8)(ignore@5.3.2)(ioredis@5.3.2)(jsdom@26.1.0)(jsonwebtoken@9.0.2)(mssql@10.0.2)(mysql2@3.9.7)(playwright@1.55.0)(promise-ftp-common@1.1.5)(socks@2.8.7)(ts-node@10.9.2(@types/node@24.3.1)(typescript@5.9.2))(ts-toolbelt@9.6.0)(typescript@5.9.2)(ws@8.14.2)':
+  '@n8n/n8n-nodes-langchain@1.44.0(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.887.0)(@azure/storage-blob@12.28.0)(@google-cloud/storage@6.12.0(encoding@0.1.13))(@sentry/node@7.87.0)(@smithy/eventstream-codec@2.2.0)(@smithy/protocol-http@3.3.0)(@smithy/signature-v4@2.3.0)(@smithy/util-utf8@2.3.0)(@supabase/postgrest-js@1.15.2)(asn1.js@5.4.1)(axios@1.6.7)(date-fns@4.1.0)(encoding@0.1.13)(fast-xml-parser@5.2.5)(gcp-metadata@5.3.0(encoding@0.1.13))(google-auth-library@8.9.0(encoding@0.1.13))(handlebars@4.7.8)(ignore@5.3.2)(ioredis@5.7.0)(jsdom@26.1.0)(jsonwebtoken@9.0.2)(mssql@10.0.2)(mysql2@3.9.7)(playwright@1.55.0)(promise-ftp-common@1.1.5)(socks@2.8.7)(ts-node@10.9.2(@types/node@24.3.1)(typescript@5.9.2))(ts-toolbelt@9.6.0)(typescript@5.9.2)(ws@8.14.2)':
     dependencies:
       '@aws-sdk/client-bedrock-runtime': 3.535.0
       '@aws-sdk/credential-provider-node': 3.535.0
@@ -14078,7 +13885,7 @@ snapshots:
       '@huggingface/inference': 2.7.0
       '@langchain/anthropic': 0.1.21(encoding@0.1.13)(openai@4.47.1(encoding@0.1.13))
       '@langchain/cohere': 0.0.10(encoding@0.1.13)(openai@4.47.1(encoding@0.1.13))
-      '@langchain/community': 0.2.2(607ef954e07105212e3a229fa0e4ebab)
+      '@langchain/community': 0.2.2(d822633e396d3d43f67a8695ba237eda)
       '@langchain/core': 0.2.0(openai@4.47.1(encoding@0.1.13))
       '@langchain/google-genai': 0.0.16(openai@4.47.1(encoding@0.1.13))(zod@3.23.8)
       '@langchain/groq': 0.0.12(encoding@0.1.13)(openai@4.47.1(encoding@0.1.13))(ws@8.14.2)
@@ -14087,7 +13894,7 @@ snapshots:
       '@langchain/pinecone': 0.0.6(openai@4.47.1(encoding@0.1.13))
       '@langchain/redis': 0.0.5(openai@4.47.1(encoding@0.1.13))
       '@langchain/textsplitters': 0.0.2(openai@4.47.1(encoding@0.1.13))
-      '@n8n/typeorm': 0.3.20-10(@sentry/node@7.87.0)(ioredis@5.3.2)(mssql@10.0.2)(mysql2@3.9.7)(pg@8.11.3)(redis@4.6.12)(sqlite3@5.1.7)(ts-node@10.9.2(@types/node@24.3.1)(typescript@5.9.2))
+      '@n8n/typeorm': 0.3.20-10(@sentry/node@7.87.0)(ioredis@5.7.0)(mssql@10.0.2)(mysql2@3.9.7)(pg@8.11.3)(redis@4.6.12)(sqlite3@5.1.7)(ts-node@10.9.2(@types/node@24.3.1)(typescript@5.9.2))
       '@n8n/vm2': 3.9.20
       '@pinecone-database/pinecone': 2.2.1
       '@qdrant/js-client-rest': 1.9.0(typescript@5.9.2)
@@ -14101,7 +13908,7 @@ snapshots:
       generate-schema: 2.6.0
       html-to-text: 9.0.5
       json-schema-to-zod: 2.1.0
-      langchain: 0.2.2(@aws-sdk/client-s3@3.887.0)(@aws-sdk/credential-provider-node@3.535.0)(@azure/storage-blob@12.28.0)(@google-ai/generativelanguage@2.5.0(encoding@0.1.13))(@pinecone-database/pinecone@2.2.1)(@supabase/supabase-js@2.43.4)(@xata.io/client@0.28.4(typescript@5.9.2))(axios@1.6.7)(d3-dsv@2.0.0)(encoding@0.1.13)(epub2@3.0.2(ts-toolbelt@9.6.0))(fast-xml-parser@5.2.5)(handlebars@4.7.8)(html-to-text@9.0.5)(ignore@5.3.2)(ioredis@5.3.2)(jsdom@26.1.0)(mammoth@1.7.2)(openai@4.47.1(encoding@0.1.13))(pdf-parse@1.1.1)(playwright@1.55.0)(redis@4.6.12)(ws@8.14.2)
+      langchain: 0.2.2(@aws-sdk/client-s3@3.887.0)(@aws-sdk/credential-provider-node@3.535.0)(@azure/storage-blob@12.28.0)(@google-ai/generativelanguage@2.5.0(encoding@0.1.13))(@pinecone-database/pinecone@2.2.1)(@supabase/supabase-js@2.43.4)(@xata.io/client@0.28.4(typescript@5.9.2))(axios@1.6.7)(d3-dsv@2.0.0)(encoding@0.1.13)(epub2@3.0.2(ts-toolbelt@9.6.0))(fast-xml-parser@5.2.5)(handlebars@4.7.8)(html-to-text@9.0.5)(ignore@5.3.2)(ioredis@5.7.0)(jsdom@26.1.0)(mammoth@1.7.2)(openai@4.47.1(encoding@0.1.13))(pdf-parse@1.1.1)(playwright@1.55.0)(redis@4.6.12)(ws@8.14.2)
       lodash: 4.17.21
       mammoth: 1.7.2
       n8n-nodes-base: 1.44.0(asn1.js@5.4.1)(date-fns@4.1.0)(encoding@0.1.13)(gcp-metadata@5.3.0(encoding@0.1.13))(promise-ftp-common@1.1.5)(socks@2.8.7)(zod@3.23.8)
@@ -14269,7 +14076,7 @@ snapshots:
       esprima-next: 5.8.4
       recast: 0.22.0
 
-  '@n8n/typeorm@0.3.20-10(@sentry/node@7.87.0)(ioredis@5.3.2)(mssql@10.0.2)(mysql2@3.9.7)(pg@8.11.3)(redis@4.6.12)(sqlite3@5.1.7)(ts-node@10.9.2(@types/node@24.3.1)(typescript@5.9.2))':
+  '@n8n/typeorm@0.3.20-10(@sentry/node@7.87.0)(ioredis@5.7.0)(mssql@10.0.2)(mysql2@3.9.7)(pg@8.11.3)(redis@4.6.12)(sqlite3@5.1.7)(ts-node@10.9.2(@types/node@24.3.1)(typescript@5.9.2))':
     dependencies:
       '@n8n/p-retry': 6.2.0-2
       '@sqltools/formatter': 1.2.5
@@ -14290,7 +14097,7 @@ snapshots:
       yargs: 17.7.2
     optionalDependencies:
       '@sentry/node': 7.87.0
-      ioredis: 5.3.2
+      ioredis: 5.7.0
       mssql: 10.0.2
       mysql2: 3.9.7
       pg: 8.11.3
@@ -14333,19 +14140,34 @@ snapshots:
       '@emnapi/runtime': 1.5.0
       '@tybys/wasm-util': 0.9.0
 
-  '@nestjs/bull-shared@11.0.3(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))':
+  '@nestjs/bull-shared@11.0.3(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.6)':
     dependencies:
-      '@nestjs/common': 11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@11.1.6)(reflect-metadata@0.1.14)(rxjs@7.8.2)
       tslib: 2.8.1
 
-  '@nestjs/bullmq@11.0.3(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(bullmq@5.58.5)':
+  '@nestjs/bullmq@11.0.3(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.6)(bullmq@5.58.5)':
     dependencies:
-      '@nestjs/bull-shared': 11.0.3(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))
-      '@nestjs/common': 11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/bull-shared': 11.0.3(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.6)
+      '@nestjs/common': 11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@11.1.6)(reflect-metadata@0.1.14)(rxjs@7.8.2)
       bullmq: 5.58.5
       tslib: 2.8.1
+
+  '@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2)':
+    dependencies:
+      file-type: 21.0.0
+      iterare: 1.2.1
+      load-esm: 1.0.2
+      reflect-metadata: 0.1.14
+      rxjs: 7.8.2
+      tslib: 2.8.1
+      uid: 2.0.2
+    optionalDependencies:
+      class-transformer: 0.5.1
+      class-validator: 0.14.2
+    transitivePeerDependencies:
+      - supports-color
 
   '@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
     dependencies:
@@ -14362,15 +14184,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@nestjs/config@4.0.2(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(rxjs@7.8.2)':
+  '@nestjs/config@4.0.2(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(rxjs@7.8.2)':
     dependencies:
-      '@nestjs/common': 11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2)
       dotenv: 16.4.7
       dotenv-expand: 12.0.1
       lodash: 4.17.21
       rxjs: 7.8.2
 
-  '@nestjs/core@11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+  '@nestjs/core@11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@11.1.6)(reflect-metadata@0.1.14)(rxjs@7.8.2)':
+    dependencies:
+      '@nestjs/common': 11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nuxt/opencollective': 0.4.1
+      fast-safe-stringify: 2.1.1
+      iterare: 1.2.1
+      path-to-regexp: 8.2.0
+      reflect-metadata: 0.1.14
+      rxjs: 7.8.2
+      tslib: 2.8.1
+      uid: 2.0.2
+    optionalDependencies:
+      '@nestjs/platform-express': 11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.6)
+
+  '@nestjs/core@11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.6)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
     dependencies:
       '@nestjs/common': 11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nuxt/opencollective': 0.4.1
@@ -14381,6 +14217,16 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
       uid: 2.0.2
+    optionalDependencies:
+      '@nestjs/platform-express': 11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6)
+
+  '@nestjs/mapped-types@2.1.0(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)':
+    dependencies:
+      '@nestjs/common': 11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      reflect-metadata: 0.1.14
+    optionalDependencies:
+      class-transformer: 0.5.1
+      class-validator: 0.14.2
 
   '@nestjs/mapped-types@2.1.0(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)':
     dependencies:
@@ -14390,11 +14236,51 @@ snapshots:
       class-transformer: 0.5.1
       class-validator: 0.14.2
 
-  '@nestjs/swagger@11.2.0(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)':
+  '@nestjs/platform-express@11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.6)':
+    dependencies:
+      '@nestjs/common': 11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@11.1.6)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      cors: 2.8.5
+      express: 5.1.0
+      multer: 2.0.2
+      path-to-regexp: 8.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@nestjs/platform-express@11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6)':
+    dependencies:
+      '@nestjs/common': 11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.6)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      cors: 2.8.5
+      express: 5.1.0
+      multer: 2.0.2
+      path-to-regexp: 8.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  '@nestjs/swagger@11.2.0(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.6)(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)':
+    dependencies:
+      '@microsoft/tsdoc': 0.15.1
+      '@nestjs/common': 11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@11.1.6)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/mapped-types': 2.1.0(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)
+      js-yaml: 4.1.0
+      lodash: 4.17.21
+      path-to-regexp: 8.2.0
+      reflect-metadata: 0.1.14
+      swagger-ui-dist: 5.21.0
+    optionalDependencies:
+      class-transformer: 0.5.1
+      class-validator: 0.14.2
+
+  '@nestjs/swagger@11.2.0(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6)(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)':
     dependencies:
       '@microsoft/tsdoc': 0.15.1
       '@nestjs/common': 11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.6)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/mapped-types': 2.1.0(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)
       js-yaml: 4.1.0
       lodash: 4.17.21
@@ -14516,7 +14402,7 @@ snapshots:
       eslint: 9.35.0(jiti@2.5.1)
       semver: 7.7.2
       tslib: 2.8.1
-      typescript: 5.8.3
+      typescript: 5.9.2
     optionalDependencies:
       '@zkochan/js-yaml': 0.0.7
     transitivePeerDependencies:
@@ -14769,10 +14655,6 @@ snapshots:
     dependencies:
       '@redis/client': 1.6.1
 
-  '@redis/bloom@5.8.2(@redis/client@5.8.2)':
-    dependencies:
-      '@redis/client': 5.8.2
-
   '@redis/client@1.5.13':
     dependencies:
       cluster-key-slot: 1.1.2
@@ -14784,10 +14666,6 @@ snapshots:
       cluster-key-slot: 1.1.2
       generic-pool: 3.9.0
       yallist: 4.0.0
-
-  '@redis/client@5.8.2':
-    dependencies:
-      cluster-key-slot: 1.1.2
 
   '@redis/graph@1.1.1(@redis/client@1.5.13)':
     dependencies:
@@ -14805,10 +14683,6 @@ snapshots:
     dependencies:
       '@redis/client': 1.6.1
 
-  '@redis/json@5.8.2(@redis/client@5.8.2)':
-    dependencies:
-      '@redis/client': 5.8.2
-
   '@redis/search@1.1.6(@redis/client@1.5.13)':
     dependencies:
       '@redis/client': 1.5.13
@@ -14817,10 +14691,6 @@ snapshots:
     dependencies:
       '@redis/client': 1.6.1
 
-  '@redis/search@5.8.2(@redis/client@5.8.2)':
-    dependencies:
-      '@redis/client': 5.8.2
-
   '@redis/time-series@1.0.5(@redis/client@1.5.13)':
     dependencies:
       '@redis/client': 1.5.13
@@ -14828,10 +14698,6 @@ snapshots:
   '@redis/time-series@1.1.0(@redis/client@1.6.1)':
     dependencies:
       '@redis/client': 1.6.1
-
-  '@redis/time-series@5.8.2(@redis/client@5.8.2)':
-    dependencies:
-      '@redis/client': 5.8.2
 
   '@reduxjs/toolkit@2.9.0(react-redux@9.2.0(@types/react@18.3.24)(react@18.3.1)(redux@5.0.1))(react@18.3.1)':
     dependencies:
@@ -15947,7 +15813,7 @@ snapshots:
 
   '@types/asn1@0.2.4':
     dependencies:
-      '@types/node': 20.19.13
+      '@types/node': 24.3.1
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -15975,7 +15841,7 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 20.19.13
+      '@types/node': 24.3.1
 
   '@types/caseless@0.12.5': {}
 
@@ -15985,27 +15851,22 @@ snapshots:
 
   '@types/cli-progress@3.11.6':
     dependencies:
-      '@types/node': 20.19.13
-
-  '@types/compression@1.8.1':
-    dependencies:
-      '@types/express': 4.17.23
-      '@types/node': 20.19.13
+      '@types/node': 24.3.1
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 20.19.13
+      '@types/node': 24.3.1
 
   '@types/conventional-commits-parser@5.0.1':
     dependencies:
-      '@types/node': 20.19.13
+      '@types/node': 24.3.1
     optional: true
 
   '@types/cookie@0.6.0': {}
 
   '@types/cors@2.8.19':
     dependencies:
-      '@types/node': 20.19.13
+      '@types/node': 24.3.1
 
   '@types/d3-array@3.2.1': {}
 
@@ -16041,14 +15902,10 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.6':
     dependencies:
-      '@types/node': 20.19.13
+      '@types/node': 24.3.1
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.5
-
-  '@types/express-session@1.18.2':
-    dependencies:
-      '@types/express': 4.17.23
 
   '@types/express@4.17.23':
     dependencies:
@@ -16065,8 +15922,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@types/js-yaml@4.0.9': {}
-
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
@@ -16074,7 +15929,7 @@ snapshots:
   '@types/jsonwebtoken@9.0.10':
     dependencies:
       '@types/ms': 2.1.0
-      '@types/node': 20.19.13
+      '@types/node': 24.3.1
 
   '@types/lodash@4.17.20': {}
 
@@ -16084,7 +15939,7 @@ snapshots:
 
   '@types/morgan@1.9.10':
     dependencies:
-      '@types/node': 20.19.13
+      '@types/node': 24.3.1
 
   '@types/ms@2.1.0': {}
 
@@ -16094,18 +15949,8 @@ snapshots:
 
   '@types/node-fetch@2.6.13':
     dependencies:
-      '@types/node': 20.19.13
+      '@types/node': 24.3.1
       form-data: 4.0.4
-
-  '@types/node@12.20.55': {}
-
-  '@types/node@18.19.124':
-    dependencies:
-      undici-types: 5.26.5
-
-  '@types/node@20.19.13':
-    dependencies:
-      undici-types: 6.21.0
 
   '@types/node@24.3.1':
     dependencies:
@@ -16114,47 +15959,11 @@ snapshots:
   '@types/nodemailer@7.0.1':
     dependencies:
       '@aws-sdk/client-sesv2': 3.883.0
-      '@types/node': 20.19.13
+      '@types/node': 24.3.1
     transitivePeerDependencies:
       - aws-crt
 
-  '@types/oauth@0.9.6':
-    dependencies:
-      '@types/node': 20.19.13
-
   '@types/parse-json@4.0.2': {}
-
-  '@types/passport-google-oauth20@2.0.16':
-    dependencies:
-      '@types/express': 4.17.23
-      '@types/passport': 1.0.17
-      '@types/passport-oauth2': 1.8.0
-
-  '@types/passport-jwt@4.0.1':
-    dependencies:
-      '@types/jsonwebtoken': 9.0.10
-      '@types/passport-strategy': 0.2.38
-
-  '@types/passport-local@1.0.38':
-    dependencies:
-      '@types/express': 4.17.23
-      '@types/passport': 1.0.17
-      '@types/passport-strategy': 0.2.38
-
-  '@types/passport-oauth2@1.8.0':
-    dependencies:
-      '@types/express': 4.17.23
-      '@types/oauth': 0.9.6
-      '@types/passport': 1.0.17
-
-  '@types/passport-strategy@0.2.38':
-    dependencies:
-      '@types/express': 4.17.23
-      '@types/passport': 1.0.17
-
-  '@types/passport@1.0.17':
-    dependencies:
-      '@types/express': 4.17.23
 
   '@types/phoenix@1.6.6': {}
 
@@ -16184,7 +15993,7 @@ snapshots:
 
   '@types/readable-stream@4.0.21':
     dependencies:
-      '@types/node': 20.19.13
+      '@types/node': 24.3.1
 
   '@types/recharts@2.0.1(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(redux@5.0.1)':
     dependencies:
@@ -16199,7 +16008,7 @@ snapshots:
   '@types/request@2.48.13':
     dependencies:
       '@types/caseless': 0.12.5
-      '@types/node': 20.19.13
+      '@types/node': 24.3.1
       '@types/tough-cookie': 4.0.5
       form-data: 2.5.5
 
@@ -16210,12 +16019,12 @@ snapshots:
   '@types/send@0.17.5':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 20.19.13
+      '@types/node': 24.3.1
 
   '@types/serve-static@1.15.8':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 20.19.13
+      '@types/node': 24.3.1
       '@types/send': 0.17.5
 
   '@types/statuses@2.0.6': {}
@@ -16247,12 +16056,12 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 20.19.13
+      '@types/node': 24.3.1
 
-  '@typescript-eslint/eslint-plugin@8.42.0(@typescript-eslint/parser@8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2)':
+  '@typescript-eslint/eslint-plugin@8.42.0(@typescript-eslint/parser@8.42.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2)
+      '@typescript-eslint/parser': 8.42.0(eslint@8.57.1)(typescript@5.9.2)
       '@typescript-eslint/scope-manager': 8.42.0
       '@typescript-eslint/type-utils': 8.42.0(eslint@8.57.1)(typescript@5.9.2)
       '@typescript-eslint/utils': 8.42.0(eslint@8.57.1)(typescript@5.9.2)
@@ -16559,6 +16368,11 @@ snapshots:
     dependencies:
       mime-types: 2.1.35
       negotiator: 0.6.3
+
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.1
+      negotiator: 1.0.0
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
@@ -16960,8 +16774,6 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  base64url@3.0.1: {}
-
   basic-auth@2.0.1:
     dependencies:
       safe-buffer: 5.1.2
@@ -17052,6 +16864,20 @@ snapshots:
       raw-body: 2.5.2
       type-is: 1.6.18
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  body-parser@2.2.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.1(supports-color@8.1.1)
+      http-errors: 2.0.0
+      iconv-lite: 0.6.3
+      on-finished: 2.4.1
+      qs: 6.14.0
+      raw-body: 3.0.1
+      type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
@@ -17533,18 +17359,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  compression@1.8.1:
-    dependencies:
-      bytes: 3.1.2
-      compressible: 2.0.18
-      debug: 2.6.9
-      negotiator: 0.6.4
-      on-headers: 1.1.0
-      safe-buffer: 5.2.1
-      vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
-
   concat-map@0.0.1: {}
 
   concat-stream@1.6.2:
@@ -17574,11 +17388,6 @@ snapshots:
 
   confusing-browser-globals@1.0.11: {}
 
-  connect-redis@9.0.0(express-session@1.18.2)(redis@5.8.2):
-    dependencies:
-      express-session: 1.18.2
-      redis: 5.8.2
-
   consola@3.4.2: {}
 
   console-control-strings@1.1.0:
@@ -17591,6 +17400,10 @@ snapshots:
       upper-case: 2.0.2
 
   content-disposition@0.5.4:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  content-disposition@1.0.0:
     dependencies:
       safe-buffer: 5.2.1
 
@@ -17612,7 +17425,7 @@ snapshots:
 
   cookie-signature@1.0.6: {}
 
-  cookie-signature@1.0.7: {}
+  cookie-signature@1.2.2: {}
 
   cookie@0.4.1: {}
 
@@ -18358,35 +18171,15 @@ snapshots:
     dependencies:
       '@next/eslint-plugin-next': 14.2.32
       '@rushstack/eslint-patch': 1.12.0
-      '@typescript-eslint/eslint-plugin': 8.42.0(@typescript-eslint/parser@8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2)
+      '@typescript-eslint/eslint-plugin': 8.42.0(@typescript-eslint/parser@8.42.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2)
       '@typescript-eslint/parser': 8.42.0(eslint@8.57.1)(typescript@5.9.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.35.0(jiti@2.5.1)))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.42.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
-    optionalDependencies:
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - eslint-import-resolver-webpack
-      - eslint-plugin-import-x
-      - supports-color
-
-  eslint-config-next@14.2.32(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2):
-    dependencies:
-      '@next/eslint-plugin-next': 14.2.32
-      '@rushstack/eslint-patch': 1.12.0
-      '@typescript-eslint/eslint-plugin': 8.42.0(@typescript-eslint/parser@8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2)
-      '@typescript-eslint/parser': 8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2)
-      eslint: 9.35.0(jiti@2.5.1)
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.35.0(jiti@2.5.1))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.35.0(jiti@2.5.1))
-      eslint-plugin-react: 7.37.5(eslint@9.35.0(jiti@2.5.1))
-      eslint-plugin-react-hooks: 4.6.2(eslint@9.35.0(jiti@2.5.1))
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -18408,7 +18201,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.35.0(jiti@2.5.1)))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.1(supports-color@8.1.1)
@@ -18419,48 +18212,32 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.35.0(jiti@2.5.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.42.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.1(supports-color@8.1.1)
-      eslint: 9.35.0(jiti@2.5.1)
-      get-tsconfig: 4.10.1
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.15
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.35.0(jiti@2.5.1))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.35.0(jiti@2.5.1)))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.42.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2)
+      '@typescript-eslint/parser': 8.42.0(eslint@8.57.1)(typescript@5.9.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.35.0(jiti@2.5.1)))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint@9.35.0(jiti@2.5.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2)
       eslint: 9.35.0(jiti@2.5.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.35.0(jiti@2.5.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.42.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -18471,7 +18248,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.35.0(jiti@2.5.1)))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.42.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -18483,36 +18260,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1)):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.9
-      array.prototype.findlastindex: 1.2.6
-      array.prototype.flat: 1.3.3
-      array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 9.35.0(jiti@2.5.1)
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
-      hasown: 2.0.2
-      is-core-module: 2.16.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.1
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.9
-      tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2)
+      '@typescript-eslint/parser': 8.42.0(eslint@8.57.1)(typescript@5.9.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -18529,7 +18277,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.35.0(jiti@2.5.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.35.0(jiti@2.5.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint@9.35.0(jiti@2.5.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -18566,25 +18314,6 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-jsx-a11y@6.10.2(eslint@9.35.0(jiti@2.5.1)):
-    dependencies:
-      aria-query: 5.3.2
-      array-includes: 3.1.9
-      array.prototype.flatmap: 1.3.3
-      ast-types-flow: 0.0.8
-      axe-core: 4.10.3
-      axobject-query: 4.1.0
-      damerau-levenshtein: 1.0.8
-      emoji-regex: 9.2.2
-      eslint: 9.35.0(jiti@2.5.1)
-      hasown: 2.0.2
-      jsx-ast-utils: 3.3.5
-      language-tags: 1.0.9
-      minimatch: 3.1.2
-      object.fromentries: 2.0.8
-      safe-regex-test: 1.1.0
-      string.prototype.includes: 2.0.1
-
   eslint-plugin-prettier@5.5.4(eslint-config-prettier@10.1.8(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))(prettier@3.6.2):
     dependencies:
       eslint: 9.35.0(jiti@2.5.1)
@@ -18598,10 +18327,6 @@ snapshots:
     dependencies:
       eslint: 8.57.1
 
-  eslint-plugin-react-hooks@4.6.2(eslint@9.35.0(jiti@2.5.1)):
-    dependencies:
-      eslint: 9.35.0(jiti@2.5.1)
-
   eslint-plugin-react@7.37.5(eslint@8.57.1):
     dependencies:
       array-includes: 3.1.9
@@ -18611,28 +18336,6 @@ snapshots:
       doctrine: 2.1.0
       es-iterator-helpers: 1.2.1
       eslint: 8.57.1
-      estraverse: 5.3.0
-      hasown: 2.0.2
-      jsx-ast-utils: 3.3.5
-      minimatch: 3.1.2
-      object.entries: 1.1.9
-      object.fromentries: 2.0.8
-      object.values: 1.2.1
-      prop-types: 15.8.1
-      resolve: 2.0.0-next.5
-      semver: 6.3.1
-      string.prototype.matchall: 4.0.12
-      string.prototype.repeat: 1.0.0
-
-  eslint-plugin-react@7.37.5(eslint@9.35.0(jiti@2.5.1)):
-    dependencies:
-      array-includes: 3.1.9
-      array.prototype.findlast: 1.2.5
-      array.prototype.flatmap: 1.3.3
-      array.prototype.tosorted: 1.1.4
-      doctrine: 2.1.0
-      es-iterator-helpers: 1.2.1
-      eslint: 9.35.0(jiti@2.5.1)
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
@@ -18860,24 +18563,6 @@ snapshots:
     dependencies:
       express: 4.19.2
 
-  express-rate-limit@8.1.0(express@4.21.2):
-    dependencies:
-      express: 4.21.2
-      ip-address: 10.0.1
-
-  express-session@1.18.2:
-    dependencies:
-      cookie: 0.7.2
-      cookie-signature: 1.0.7
-      debug: 2.6.9
-      depd: 2.0.0
-      on-headers: 1.1.0
-      parseurl: 1.3.3
-      safe-buffer: 5.2.1
-      uid-safe: 2.1.5
-    transitivePeerDependencies:
-      - supports-color
-
   express@4.19.2:
     dependencies:
       accepts: 1.3.8
@@ -18946,6 +18631,38 @@ snapshots:
       statuses: 2.0.1
       type-is: 1.6.18
       utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.1.0:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.0
+      content-disposition: 1.0.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.1(supports-color@8.1.1)
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.0
+      fresh: 2.0.0
+      http-errors: 2.0.0
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.1
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.14.0
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.0
+      serve-static: 2.2.0
+      statuses: 2.0.2
+      type-is: 2.0.1
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
@@ -19095,6 +18812,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  finalhandler@2.1.0:
+    dependencies:
+      debug: 4.4.1(supports-color@8.1.1)
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-config@1.0.0:
     dependencies:
       user-home: 2.0.0
@@ -19212,6 +18940,8 @@ snapshots:
   fraction.js@4.3.7: {}
 
   fresh@0.5.2: {}
+
+  fresh@2.0.0: {}
 
   front-matter@4.0.2:
     dependencies:
@@ -19556,7 +19286,7 @@ snapshots:
 
   groq-sdk@0.3.3(encoding@0.1.13):
     dependencies:
-      '@types/node': 18.19.124
+      '@types/node': 24.3.1
       '@types/node-fetch': 2.6.13
       abort-controller: 3.0.0
       agentkeepalive: 4.6.0
@@ -19748,6 +19478,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  iconv-lite@0.7.0:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ics@2.40.0:
     dependencies:
       nanoid: 3.3.11
@@ -19864,20 +19598,6 @@ snapshots:
 
   interpret@1.4.0: {}
 
-  ioredis@5.3.2:
-    dependencies:
-      '@ioredis/commands': 1.3.1
-      cluster-key-slot: 1.1.2
-      debug: 4.4.1(supports-color@8.1.1)
-      denque: 2.1.0
-      lodash.defaults: 4.2.0
-      lodash.isarguments: 3.1.0
-      redis-errors: 1.2.0
-      redis-parser: 3.0.0
-      standard-as-callback: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
-
   ioredis@5.7.0:
     dependencies:
       '@ioredis/commands': 1.3.1
@@ -19892,7 +19612,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ip-address@10.0.1: {}
+  ip-address@10.0.1:
+    optional: true
 
   ipaddr.js@1.9.1: {}
 
@@ -20012,6 +19733,8 @@ snapshots:
   is-path-inside@3.0.3: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  is-promise@4.0.0: {}
 
   is-property@1.0.2: {}
 
@@ -20306,7 +20029,7 @@ snapshots:
 
   kuler@2.0.0: {}
 
-  langchain@0.2.2(@aws-sdk/client-s3@3.887.0)(@aws-sdk/credential-provider-node@3.535.0)(@azure/storage-blob@12.28.0)(@google-ai/generativelanguage@2.5.0(encoding@0.1.13))(@pinecone-database/pinecone@2.1.0)(@supabase/supabase-js@2.43.4)(@xata.io/client@0.28.4(typescript@5.9.2))(axios@1.6.7)(d3-dsv@2.0.0)(encoding@0.1.13)(epub2@3.0.2(ts-toolbelt@9.6.0))(fast-xml-parser@5.2.5)(handlebars@4.7.8)(html-to-text@9.0.5)(ignore@5.3.2)(ioredis@5.3.2)(jsdom@26.1.0)(mammoth@1.7.2)(openai@5.20.0(ws@8.14.2)(zod@3.22.4))(pdf-parse@1.1.1)(playwright@1.55.0)(redis@4.6.12)(ws@8.14.2):
+  langchain@0.2.2(@aws-sdk/client-s3@3.887.0)(@aws-sdk/credential-provider-node@3.535.0)(@azure/storage-blob@12.28.0)(@google-ai/generativelanguage@2.5.0(encoding@0.1.13))(@pinecone-database/pinecone@2.1.0)(@supabase/supabase-js@2.43.4)(@xata.io/client@0.28.4(typescript@5.9.2))(axios@1.6.7)(d3-dsv@2.0.0)(encoding@0.1.13)(epub2@3.0.2(ts-toolbelt@9.6.0))(fast-xml-parser@5.2.5)(handlebars@4.7.8)(html-to-text@9.0.5)(ignore@5.3.2)(ioredis@5.7.0)(jsdom@26.1.0)(mammoth@1.7.2)(openai@5.20.0(ws@8.14.2)(zod@3.22.4))(pdf-parse@1.1.1)(playwright@1.55.0)(redis@4.6.12)(ws@8.14.2):
     dependencies:
       '@langchain/core': 0.2.0(openai@5.20.0(ws@8.14.2)(zod@3.22.4))
       '@langchain/openai': 0.0.33(encoding@0.1.13)(ws@8.14.2)
@@ -20339,7 +20062,7 @@ snapshots:
       handlebars: 4.7.8
       html-to-text: 9.0.5
       ignore: 5.3.2
-      ioredis: 5.3.2
+      ioredis: 5.7.0
       jsdom: 26.1.0
       mammoth: 1.7.2
       pdf-parse: 1.1.1
@@ -20350,7 +20073,7 @@ snapshots:
       - encoding
       - openai
 
-  langchain@0.2.2(@aws-sdk/client-s3@3.887.0)(@aws-sdk/credential-provider-node@3.535.0)(@azure/storage-blob@12.28.0)(@google-ai/generativelanguage@2.5.0(encoding@0.1.13))(@pinecone-database/pinecone@2.2.1)(@supabase/supabase-js@2.43.4)(@xata.io/client@0.28.4(typescript@5.9.2))(axios@1.6.7)(d3-dsv@2.0.0)(encoding@0.1.13)(epub2@3.0.2(ts-toolbelt@9.6.0))(fast-xml-parser@5.2.5)(handlebars@4.7.8)(html-to-text@9.0.5)(ignore@5.3.2)(ioredis@5.3.2)(jsdom@26.1.0)(mammoth@1.7.2)(openai@4.47.1(encoding@0.1.13))(pdf-parse@1.1.1)(playwright@1.55.0)(redis@4.6.12)(ws@8.14.2):
+  langchain@0.2.2(@aws-sdk/client-s3@3.887.0)(@aws-sdk/credential-provider-node@3.535.0)(@azure/storage-blob@12.28.0)(@google-ai/generativelanguage@2.5.0(encoding@0.1.13))(@pinecone-database/pinecone@2.2.1)(@supabase/supabase-js@2.43.4)(@xata.io/client@0.28.4(typescript@5.9.2))(axios@1.6.7)(d3-dsv@2.0.0)(encoding@0.1.13)(epub2@3.0.2(ts-toolbelt@9.6.0))(fast-xml-parser@5.2.5)(handlebars@4.7.8)(html-to-text@9.0.5)(ignore@5.3.2)(ioredis@5.7.0)(jsdom@26.1.0)(mammoth@1.7.2)(openai@4.47.1(encoding@0.1.13))(pdf-parse@1.1.1)(playwright@1.55.0)(redis@4.6.12)(ws@8.14.2):
     dependencies:
       '@langchain/core': 0.2.0(openai@4.47.1(encoding@0.1.13))
       '@langchain/openai': 0.0.33(encoding@0.1.13)(ws@8.14.2)
@@ -20383,7 +20106,7 @@ snapshots:
       handlebars: 4.7.8
       html-to-text: 9.0.5
       ignore: 5.3.2
-      ioredis: 5.3.2
+      ioredis: 5.7.0
       jsdom: 26.1.0
       mammoth: 1.7.2
       pdf-parse: 1.1.1
@@ -20438,7 +20161,7 @@ snapshots:
   ldapts@4.2.6:
     dependencies:
       '@types/asn1': 0.2.4
-      '@types/node': 20.19.13
+      '@types/node': 24.3.1
       '@types/uuid': 9.0.8
       asn1: 0.2.6
       debug: 4.3.7
@@ -20731,6 +20454,8 @@ snapshots:
 
   merge-descriptors@1.0.3: {}
 
+  merge-descriptors@2.0.0: {}
+
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
@@ -20751,6 +20476,10 @@ snapshots:
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.1:
+    dependencies:
+      mime-db: 1.54.0
 
   mime@1.6.0: {}
 
@@ -21016,6 +20745,16 @@ snapshots:
       type-is: 1.6.18
       xtend: 4.0.2
 
+  multer@2.0.2:
+    dependencies:
+      append-field: 1.0.0
+      busboy: 1.6.0
+      concat-stream: 2.0.0
+      mkdirp: 0.5.6
+      object-assign: 4.1.1
+      type-is: 1.6.18
+      xtend: 4.0.2
+
   mustache@4.2.0: {}
 
   mute-stream@0.0.7: {}
@@ -21267,15 +21006,15 @@ snapshots:
 
   n8n@1.44.0(3622031ac23aa4b38abacc1388a9cf03):
     dependencies:
-      '@langchain/community': 0.2.2(aa2844e97b0f2d20793211e4fa3c4e54)
+      '@langchain/community': 0.2.2(8b4d0dd5e51a1bff0585c680b5a6468c)
       '@langchain/core': 0.2.0(openai@5.20.0(ws@8.14.2)(zod@3.22.4))
       '@langchain/openai': 0.0.33(encoding@0.1.13)(ws@8.14.2)
       '@langchain/pinecone': 0.0.6(openai@5.20.0(ws@8.14.2)(zod@3.22.4))
       '@n8n/client-oauth2': 0.15.0
       '@n8n/localtunnel': 2.1.0
-      '@n8n/n8n-nodes-langchain': 1.44.0(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.887.0)(@azure/storage-blob@12.28.0)(@google-cloud/storage@6.12.0(encoding@0.1.13))(@sentry/node@7.87.0)(@smithy/eventstream-codec@2.2.0)(@smithy/protocol-http@3.3.0)(@smithy/signature-v4@2.3.0)(@smithy/util-utf8@2.3.0)(@supabase/postgrest-js@1.15.2)(asn1.js@5.4.1)(axios@1.6.7)(date-fns@4.1.0)(encoding@0.1.13)(fast-xml-parser@5.2.5)(gcp-metadata@5.3.0(encoding@0.1.13))(google-auth-library@8.9.0(encoding@0.1.13))(handlebars@4.7.8)(ignore@5.3.2)(ioredis@5.3.2)(jsdom@26.1.0)(jsonwebtoken@9.0.2)(mssql@10.0.2)(mysql2@3.9.7)(playwright@1.55.0)(promise-ftp-common@1.1.5)(socks@2.8.7)(ts-node@10.9.2(@types/node@24.3.1)(typescript@5.9.2))(ts-toolbelt@9.6.0)(typescript@5.9.2)(ws@8.14.2)
+      '@n8n/n8n-nodes-langchain': 1.44.0(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.887.0)(@azure/storage-blob@12.28.0)(@google-cloud/storage@6.12.0(encoding@0.1.13))(@sentry/node@7.87.0)(@smithy/eventstream-codec@2.2.0)(@smithy/protocol-http@3.3.0)(@smithy/signature-v4@2.3.0)(@smithy/util-utf8@2.3.0)(@supabase/postgrest-js@1.15.2)(asn1.js@5.4.1)(axios@1.6.7)(date-fns@4.1.0)(encoding@0.1.13)(fast-xml-parser@5.2.5)(gcp-metadata@5.3.0(encoding@0.1.13))(google-auth-library@8.9.0(encoding@0.1.13))(handlebars@4.7.8)(ignore@5.3.2)(ioredis@5.7.0)(jsdom@26.1.0)(jsonwebtoken@9.0.2)(mssql@10.0.2)(mysql2@3.9.7)(playwright@1.55.0)(promise-ftp-common@1.1.5)(socks@2.8.7)(ts-node@10.9.2(@types/node@24.3.1)(typescript@5.9.2))(ts-toolbelt@9.6.0)(typescript@5.9.2)(ws@8.14.2)
       '@n8n/permissions': 0.7.0
-      '@n8n/typeorm': 0.3.20-10(@sentry/node@7.87.0)(ioredis@5.3.2)(mssql@10.0.2)(mysql2@3.9.7)(pg@8.11.3)(redis@4.6.12)(sqlite3@5.1.7)(ts-node@10.9.2(@types/node@24.3.1)(typescript@5.9.2))
+      '@n8n/typeorm': 0.3.20-10(@sentry/node@7.87.0)(ioredis@5.7.0)(mssql@10.0.2)(mysql2@3.9.7)(pg@8.11.3)(redis@4.6.12)(sqlite3@5.1.7)(ts-node@10.9.2(@types/node@24.3.1)(typescript@5.9.2))
       '@n8n_io/license-sdk': 2.12.0
       '@oclif/core': 3.26.6
       '@pinecone-database/pinecone': 2.1.0
@@ -21313,12 +21052,12 @@ snapshots:
       helmet: 7.1.0
       infisical-node: 1.3.0
       inquirer: 7.3.3
-      ioredis: 5.3.2
+      ioredis: 5.7.0
       isbot: 3.6.13
       json-diff: 1.0.6
       jsonschema: 1.4.1
       jsonwebtoken: 9.0.2
-      langchain: 0.2.2(@aws-sdk/client-s3@3.887.0)(@aws-sdk/credential-provider-node@3.535.0)(@azure/storage-blob@12.28.0)(@google-ai/generativelanguage@2.5.0(encoding@0.1.13))(@pinecone-database/pinecone@2.1.0)(@supabase/supabase-js@2.43.4)(@xata.io/client@0.28.4(typescript@5.9.2))(axios@1.6.7)(d3-dsv@2.0.0)(encoding@0.1.13)(epub2@3.0.2(ts-toolbelt@9.6.0))(fast-xml-parser@5.2.5)(handlebars@4.7.8)(html-to-text@9.0.5)(ignore@5.3.2)(ioredis@5.3.2)(jsdom@26.1.0)(mammoth@1.7.2)(openai@5.20.0(ws@8.14.2)(zod@3.22.4))(pdf-parse@1.1.1)(playwright@1.55.0)(redis@4.6.12)(ws@8.14.2)
+      langchain: 0.2.2(@aws-sdk/client-s3@3.887.0)(@aws-sdk/credential-provider-node@3.535.0)(@azure/storage-blob@12.28.0)(@google-ai/generativelanguage@2.5.0(encoding@0.1.13))(@pinecone-database/pinecone@2.1.0)(@supabase/supabase-js@2.43.4)(@xata.io/client@0.28.4(typescript@5.9.2))(axios@1.6.7)(d3-dsv@2.0.0)(encoding@0.1.13)(epub2@3.0.2(ts-toolbelt@9.6.0))(fast-xml-parser@5.2.5)(handlebars@4.7.8)(html-to-text@9.0.5)(ignore@5.3.2)(ioredis@5.7.0)(jsdom@26.1.0)(mammoth@1.7.2)(openai@5.20.0(ws@8.14.2)(zod@3.22.4))(pdf-parse@1.1.1)(playwright@1.55.0)(redis@4.6.12)(ws@8.14.2)
       ldapts: 4.2.6
       lodash: 4.17.21
       luxon: 3.3.0
@@ -21357,7 +21096,7 @@ snapshots:
       typedi: 0.10.0
       uuid: 8.3.2
       validator: 13.7.0
-      winston: 3.8.2
+      winston: 3.17.0
       ws: 8.14.2
       xml2js: 0.6.2
       xmllint-wasm: 3.0.1
@@ -21539,7 +21278,10 @@ snapshots:
 
   negotiator@0.6.3: {}
 
-  negotiator@0.6.4: {}
+  negotiator@0.6.4:
+    optional: true
+
+  negotiator@1.0.0: {}
 
   neo-async@2.6.2: {}
 
@@ -21766,11 +21508,7 @@ snapshots:
 
   oauth-1.0a@2.2.6: {}
 
-  oauth@0.10.2: {}
-
   object-assign@4.1.1: {}
-
-  object-hash@2.2.0: {}
 
   object-hash@3.0.0: {}
 
@@ -21876,7 +21614,7 @@ snapshots:
 
   openai@4.104.0(encoding@0.1.13)(ws@8.14.2)(zod@3.25.76):
     dependencies:
-      '@types/node': 18.19.124
+      '@types/node': 24.3.1
       '@types/node-fetch': 2.6.13
       abort-controller: 3.0.0
       agentkeepalive: 4.6.0
@@ -21891,7 +21629,7 @@ snapshots:
 
   openai@4.47.1(encoding@0.1.13):
     dependencies:
-      '@types/node': 18.19.124
+      '@types/node': 24.3.1
       '@types/node-fetch': 2.6.13
       abort-controller: 3.0.0
       agentkeepalive: 4.6.0
@@ -22074,35 +21812,6 @@ snapshots:
       no-case: 3.0.4
       tslib: 2.8.1
 
-  passport-google-oauth20@2.0.0:
-    dependencies:
-      passport-oauth2: 1.8.0
-
-  passport-jwt@4.0.1:
-    dependencies:
-      jsonwebtoken: 9.0.2
-      passport-strategy: 1.0.0
-
-  passport-local@1.0.0:
-    dependencies:
-      passport-strategy: 1.0.0
-
-  passport-oauth2@1.8.0:
-    dependencies:
-      base64url: 3.0.1
-      oauth: 0.10.2
-      passport-strategy: 1.0.0
-      uid2: 0.0.4
-      utils-merge: 1.0.1
-
-  passport-strategy@1.0.0: {}
-
-  passport@0.7.0:
-    dependencies:
-      passport-strategy: 1.0.0
-      pause: 0.0.1
-      utils-merge: 1.0.1
-
   password-prompt@1.1.3:
     dependencies:
       ansi-escapes: 4.3.2
@@ -22146,8 +21855,6 @@ snapshots:
   pathe@2.0.3: {}
 
   pathval@2.0.1: {}
-
-  pause@0.0.1: {}
 
   pdf-parse@1.1.1:
     dependencies:
@@ -22278,14 +21985,6 @@ snapshots:
     dependencies:
       camelcase-css: 2.0.1
       postcss: 8.5.6
-
-  postcss-load-config@4.0.2(postcss@8.5.6)(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.2)):
-    dependencies:
-      lilconfig: 3.1.3
-      yaml: 2.8.1
-    optionalDependencies:
-      postcss: 8.5.6
-      ts-node: 10.9.2(@types/node@20.19.13)(typescript@5.9.2)
 
   postcss-load-config@4.0.2(postcss@8.5.6)(ts-node@10.9.2(@types/node@24.3.1)(typescript@5.9.2)):
     dependencies:
@@ -22434,7 +22133,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 20.19.13
+      '@types/node': 24.3.1
       long: 5.3.2
 
   proxy-addr@2.0.7:
@@ -22526,6 +22225,13 @@ snapshots:
       bytes: 3.1.2
       http-errors: 2.0.0
       iconv-lite: 0.4.24
+      unpipe: 1.0.0
+
+  raw-body@3.0.1:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.0
+      iconv-lite: 0.7.0
       unpipe: 1.0.0
 
   rc9@2.1.2:
@@ -22691,19 +22397,13 @@ snapshots:
       '@redis/search': 1.2.0(@redis/client@1.6.1)
       '@redis/time-series': 1.1.0(@redis/client@1.6.1)
 
-  redis@5.8.2:
-    dependencies:
-      '@redis/bloom': 5.8.2(@redis/client@5.8.2)
-      '@redis/client': 5.8.2
-      '@redis/json': 5.8.2(@redis/client@5.8.2)
-      '@redis/search': 5.8.2(@redis/client@5.8.2)
-      '@redis/time-series': 5.8.2(@redis/client@5.8.2)
-
   redux-thunk@3.1.0(redux@5.0.1):
     dependencies:
       redux: 5.0.1
 
   redux@5.0.1: {}
+
+  reflect-metadata@0.1.14: {}
 
   reflect-metadata@0.2.2: {}
 
@@ -22848,10 +22548,6 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
-  rimraf@5.0.10:
-    dependencies:
-      glob: 10.4.5
-
   rimraf@6.0.1:
     dependencies:
       glob: 11.0.3
@@ -22885,6 +22581,16 @@ snapshots:
       '@rollup/rollup-win32-ia32-msvc': 4.50.1
       '@rollup/rollup-win32-x64-msvc': 4.50.1
       fsevents: 2.3.3
+
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.1(supports-color@8.1.1)
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.2.0
+    transitivePeerDependencies:
+      - supports-color
 
   rrule@2.8.1:
     dependencies:
@@ -23021,6 +22727,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  send@1.2.0:
+    dependencies:
+      debug: 4.4.1(supports-color@8.1.1)
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.0
+      mime-types: 3.0.1
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   sentence-case@3.0.4:
     dependencies:
       no-case: 3.0.4
@@ -23048,6 +22770,15 @@ snapshots:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.19.0
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.0:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.0
     transitivePeerDependencies:
       - supports-color
 
@@ -23583,33 +23314,6 @@ snapshots:
 
   syslog-client@1.1.1: {}
 
-  tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.2)):
-    dependencies:
-      '@alloc/quick-lru': 5.2.0
-      arg: 5.0.2
-      chokidar: 3.6.0
-      didyoumean: 1.2.2
-      dlv: 1.1.3
-      fast-glob: 3.3.3
-      glob-parent: 6.0.2
-      is-glob: 4.0.3
-      jiti: 1.21.7
-      lilconfig: 3.1.3
-      micromatch: 4.0.8
-      normalize-path: 3.0.0
-      object-hash: 3.0.0
-      picocolors: 1.1.1
-      postcss: 8.5.6
-      postcss-import: 15.1.0(postcss@8.5.6)
-      postcss-js: 4.0.1(postcss@8.5.6)
-      postcss-load-config: 4.0.2(postcss@8.5.6)(ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.2))
-      postcss-nested: 6.2.0(postcss@8.5.6)
-      postcss-selector-parser: 6.1.2
-      resolve: 1.22.10
-      sucrase: 3.35.0
-    transitivePeerDependencies:
-      - ts-node
-
   tailwindcss@3.4.17(ts-node@10.9.2(@types/node@24.3.1)(typescript@5.9.2)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
@@ -23840,25 +23544,6 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.2):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.19.13
-      acorn: 8.15.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.9.2
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optional: true
-
   ts-node@10.9.2(@types/node@24.3.1)(typescript@5.9.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -23881,7 +23566,7 @@ snapshots:
 
   ts-type@3.0.1(ts-toolbelt@9.6.0):
     dependencies:
-      '@types/node': 20.19.13
+      '@types/node': 24.3.1
       ts-toolbelt: 9.6.0
       tslib: 2.8.1
       typedarray-dts: 1.0.0
@@ -23943,6 +23628,12 @@ snapshots:
       media-typer: 0.3.0
       mime-types: 2.1.35
 
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.1
+
   type-of-is@3.5.1: {}
 
   typed-array-buffer@1.0.3:
@@ -23995,8 +23686,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  typescript@5.8.3: {}
-
   typescript@5.9.2: {}
 
   uc.micro@2.1.0: {}
@@ -24007,8 +23696,6 @@ snapshots:
   uid-safe@2.1.5:
     dependencies:
       random-bytes: 1.0.0
-
-  uid2@0.0.4: {}
 
   uid@2.0.2:
     dependencies:
@@ -24024,10 +23711,6 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   underscore@1.13.7: {}
-
-  undici-types@5.26.5: {}
-
-  undici-types@6.21.0: {}
 
   undici-types@7.10.0: {}
 
@@ -24363,14 +24046,6 @@ snapshots:
     dependencies:
       string-width: 4.2.3
 
-  winston-daily-rotate-file@4.7.1(winston@3.17.0):
-    dependencies:
-      file-stream-rotator: 0.6.1
-      object-hash: 2.2.0
-      triple-beam: 1.4.1
-      winston: 3.17.0
-      winston-transport: 4.9.0
-
   winston-daily-rotate-file@5.0.0(winston@3.17.0):
     dependencies:
       file-stream-rotator: 0.6.1
@@ -24388,20 +24063,6 @@ snapshots:
   winston@3.17.0:
     dependencies:
       '@colors/colors': 1.6.0
-      '@dabh/diagnostics': 2.0.3
-      async: 3.2.6
-      is-stream: 2.0.1
-      logform: 2.7.0
-      one-time: 1.0.0
-      readable-stream: 3.6.2
-      safe-stable-stringify: 2.5.0
-      stack-trace: 0.0.10
-      triple-beam: 1.4.1
-      winston-transport: 4.9.0
-
-  winston@3.8.2:
-    dependencies:
-      '@colors/colors': 1.5.0
       '@dabh/diagnostics': 2.0.3
       async: 3.2.6
       is-stream: 2.0.1

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,5 +1,5 @@
 /**
- * Description : tsconfig.base.json - 📌 루트 TypeScript 공통 설정(호이스팅 적용)
+ * Description : tsconfig.base.json - 📌 루트 TypeScript 공통 설정 (호이스팅 적용)
  * Author : Shiwoo Min
  * Date : 2025-09-06
  */
@@ -9,7 +9,7 @@
     // 절대경로 import를 위한 기준 디렉터리
     "baseUrl": ".",
 
-    // 런타임 타겟/라이브러리 (Node.js 18+)
+    // 런타임 타깃/라이브러리 (Node.js 18+)
     "target": "ES2022",
 
     // 서버/라이브러리 기본값 (ESM/Node.js)
@@ -19,10 +19,12 @@
     "moduleResolution": "NodeNext",
 
     // 서버/라이브러리 공통은 ES 표준
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    // 기존: "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022"],
 
     // 전역 타입 정의
-    "types": ["node"],
+    // (웹과 충돌 방지 위해 공통에선 고정하지 않음. Node 패키지에서만 추가)
+    // "types": ["node"],
 
     // 타입 검사 관련
     "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "baseUrl": ".",
 
     // 타입 정의 파일 경로 지정
-    "typeRoots": ["./node_modules/@types"],
+    // (모노레포에선 기본 탐색이 더 안전하므로 비활성화)
+    // "typeRoots": ["./node_modules/@types"],
 
     // 타입 선언 파일(.d.ts) 관련
     // "declarationMap": true,
@@ -48,13 +49,18 @@
 
     // 런타임 타깃/라이브러리
     "target": "ES2022",
-    "lib": ["ES2022", "DOM"],
+    // 루트는 DOM 타입 유입을 막기 위해 ES 전용으로 축소
+    // 기존: "lib": ["ES2022", "DOM"],
+    "lib": ["ES2022"],
 
     // 경로 별칭은 tsconfig.base.json에서 통합 관리
     // "paths": { ... },
 
     // 엄격 모드 설정
-    "strict": true
+    "strict": true,
+
+    // TS5 ESM 감지 강화 (권장)
+    "moduleDetection": "force"
   },
 
   // 루트 프로젝트는 빈 파일 배열 - references로만 관리


### PR DESCRIPTION
- 루트에서 공통 의존성 hoist 및 중복 제거
- 서버(Node): NodeNext / 웹(브라우저): ESNext + Bundler로 모듈 전략 분리
- Project References / incremental / tsBuildInfoFile로 빌드 속도 최적화
- Nest API: `experimentalDecorators` / `emitDecoratorMetadata` / `useDefineForClassFields` 표준화
- 컴파일 옵션 정리: `skipLibCheck`, `strict`, `include/exclude` 최소화
- Next(Apps): noEmit, 경로 매핑은 앱 내부만 사용; 패키지는 `@connectwon/*` 임포트로 통일
- e2e: Node+DOM 타입 구성만 유지, 교차 패키지 소스 직접 포함 제거
- 각 패키지 `package.json`의 **scripts / exports / types** 정비